### PR TITLE
cblocks implementation

### DIFF
--- a/db/dbmodel_mock.go
+++ b/db/dbmodel_mock.go
@@ -15,7 +15,7 @@ type MockPersist struct {
 	Transactions                     map[string]*Transactions
 	Outputs                          map[string]*Outputs
 	OutputsRedeeming                 map[string]*OutputsRedeeming
-	CvmTransactions                  map[string]*CvmTransactions
+	CvmTransactionsAtomic            map[string]*CvmTransactionsAtomic
 	CvmTransactionsTxdata            map[string]*CvmTransactionsTxdata
 	CvmBlocks                        map[string]*CvmBlocks
 	CvmAddresses                     map[string]*CvmAddresses
@@ -50,7 +50,7 @@ func NewPersistMock() *MockPersist {
 		Transactions:                     make(map[string]*Transactions),
 		Outputs:                          make(map[string]*Outputs),
 		OutputsRedeeming:                 make(map[string]*OutputsRedeeming),
-		CvmTransactions:                  make(map[string]*CvmTransactions),
+		CvmTransactionsAtomic:            make(map[string]*CvmTransactionsAtomic),
 		CvmTransactionsTxdata:            make(map[string]*CvmTransactionsTxdata),
 		CvmBlocks:                        make(map[string]*CvmBlocks),
 		CvmAddresses:                     make(map[string]*CvmAddresses),
@@ -81,7 +81,7 @@ func NewPersistMock() *MockPersist {
 	}
 }
 
-func (m *MockPersist) QueryTransactions(ctx context.Context, runner dbr.SessionRunner, v *Transactions) (*Transactions, error) {
+func (m *MockPersist) QueryTransactionsAtomic(ctx context.Context, runner dbr.SessionRunner, v *Transactions) (*Transactions, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if v, present := m.Transactions[v.ID]; present {
@@ -90,7 +90,7 @@ func (m *MockPersist) QueryTransactions(ctx context.Context, runner dbr.SessionR
 	return nil, nil
 }
 
-func (m *MockPersist) InsertTransactions(ctx context.Context, runner dbr.SessionRunner, v *Transactions, b bool) error {
+func (m *MockPersist) InsertTransactionsAtomic(ctx context.Context, runner dbr.SessionRunner, v *Transactions, b bool) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	nv := &Transactions{}
@@ -234,7 +234,7 @@ func (m *MockPersist) InsertTransactionsEpoch(ctx context.Context, runner dbr.Se
 	return nil
 }
 
-func (m *MockPersist) QueryCvmBlocks(ctx context.Context, runner dbr.SessionRunner, v *CvmBlocks) (*CvmBlocks, error) {
+func (m *MockPersist) QueryCvmBlock(ctx context.Context, runner dbr.SessionRunner, v *CvmBlocks) (*CvmBlocks, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if v, present := m.CvmBlocks[v.Block]; present {
@@ -270,21 +270,21 @@ func (m *MockPersist) InsertCvmAddresses(ctx context.Context, runner dbr.Session
 	return nil
 }
 
-func (m *MockPersist) QueryCvmTransactions(ctx context.Context, runner dbr.SessionRunner, v *CvmTransactions) (*CvmTransactions, error) {
+func (m *MockPersist) QueryCvmTransactionsAtomic(ctx context.Context, runner dbr.SessionRunner, v *CvmTransactionsAtomic) (*CvmTransactionsAtomic, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	if v, present := m.CvmTransactions[v.ID]; present {
+	if v, present := m.CvmTransactionsAtomic[v.TransactionID]; present {
 		return v, nil
 	}
 	return nil, nil
 }
 
-func (m *MockPersist) InsertCvmTransactions(ctx context.Context, runner dbr.SessionRunner, v *CvmTransactions, b bool) error {
+func (m *MockPersist) InsertCvmTransactionsAtomic(ctx context.Context, runner dbr.SessionRunner, v *CvmTransactionsAtomic, b bool) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	nv := &CvmTransactions{}
+	nv := &CvmTransactionsAtomic{}
 	*nv = *v
-	m.CvmTransactions[v.ID] = nv
+	m.CvmTransactionsAtomic[v.TransactionID] = nv
 	return nil
 }
 

--- a/models/collections.go
+++ b/models/collections.go
@@ -63,6 +63,50 @@ type CTransactionData struct {
 	Receipt *types.Receipt `json:"receipt"`
 }
 
+type CBlockHeaderBase struct {
+	Hash       string `json:"hash"`
+	Coinbase   string `json:"miner"`
+	Difficulty string `json:"difficulty"`
+	Number     string `json:"number"`
+	GasLimit   string `json:"gasLimit"`
+	GasUsed    string `json:"gasUsed"`
+	Time       string `json:"timestamp"`
+	BaseFee    string `json:"baseFeePerGas"`
+
+	ExtDataGasUsed string `json:"extDataGasUsed,omitempty"`
+	BlockGasCost   string `json:"blockGasCost,omitempty"`
+
+	EvmTx    int16 `json:"evmTx,omitempty"`
+	AtomicTx int16 `json:"atomicTx,omitempty"`
+}
+
+type CTransactionDataBase struct {
+	Type      string `json:"type"`
+	Block     string `json:"block"`
+	Index     string `json:"index"`
+	Hash      string `json:"hash"`
+	Nonce     string `json:"nonce"`
+	GasPrice  string `json:"gasPrice,omitempty"`
+	GasFeeCap string `json:"maxFeePerGas,omitempty"`
+	GasTipCap string `json:"maxPriorityFeePerGas,omitempty"`
+	Gas       string `json:"gas"`
+	Amount    string `json:"value"`
+	From      string `json:"from"`
+	To        string `json:"to,omitempty"`
+
+	CreatedAt string `json:"timestamp"`
+	Status    string `json:"status"`
+	GasUsed   string `json:"gasUsed"`
+}
+
+type CBlockList struct {
+	BlockCount       uint64 `json:"blockCount"`
+	TransactionCount uint64 `json:"transactionCount"`
+
+	Blocks       []*CBlockHeaderBase     `json:"blocks"`
+	Transactions []*CTransactionDataBase `json:"transactions"`
+}
+
 type CTransactionList struct {
 	Transactions []*CTransactionData
 	// StartTime is the calculated start time rounded to the nearest

--- a/modelsc/cblock.go
+++ b/modelsc/cblock.go
@@ -128,6 +128,8 @@ func (c *Client) Close() {
 
 type TransactionReceipt struct {
 	Hash    string `json:"hash"`
+	Status  uint16 `json:"status"`
+	GasUsed uint64 `json:"gasUsed"`
 	Receipt []byte `json:"receipt"`
 }
 
@@ -168,6 +170,8 @@ func (c *Client) ReadBlock(blockNumber *big.Int, rpcTimeout time.Duration) (*Blo
 
 		txReceipts = append(txReceipts, &TransactionReceipt{
 			Hash:    txh,
+			Status:  uint16(result.Status),
+			GasUsed: result.GasUsed,
 			Receipt: receiptBits,
 		})
 	}

--- a/services/db/migrations/020_cvm.down.sql
+++ b/services/db/migrations/020_cvm.down.sql
@@ -1,3 +1,3 @@
 drop table `cvm_blocks`;
-drop table `cvm_transactions`;
+drop table `cvm_transactions_atomic`;
 drop table `cvm_addresses`;

--- a/services/db/migrations/020_cvm.up.sql
+++ b/services/db/migrations/020_cvm.up.sql
@@ -1,16 +1,21 @@
 create table `cvm_blocks`
 (
-    block decimal(65) not null primary key,
-    created_at              timestamp        not null default current_timestamp
+    block         decimal(65)      not null primary key,
+    hash          varchar(100)     not null,
+    chain_id      varchar(50)      not null,
+    evm_tx        smallint         not null default 0,
+    atomic_tx     smallint         not null default 0,
+    serialization mediumblob,
+    created_at    timestamp        not null default current_timestamp
 );
 
-create table `cvm_transactions`
+create table `cvm_transactions_atomic`
 (
-    id             varchar(50)     not null primary key,
-    type           smallint        not null,
-    blockchain_id  varchar(50)     not null,
+    transaction_id varchar(50)     not null primary key,    
     block          decimal(65)     not null,
-    created_at                     timestamp       not null default current_timestamp
+    chain_id       varchar(50)     not null,
+    type           smallint        not null,
+    created_at                     timestamp not null default current_timestamp
 );
 
 create table `cvm_addresses`
@@ -26,4 +31,5 @@ create table `cvm_addresses`
     created_at     timestamp       not null default current_timestamp
 );
 
+create index cvm_blocks_hash ON cvm_blocks (hash);
 create index cvm_address_transaction_id ON cvm_addresses (transaction_id);

--- a/services/db/migrations/025_ser.up.sql
+++ b/services/db/migrations/025_ser.up.sql
@@ -6,7 +6,7 @@ alter table `avm_outputs_redeeming`  MODIFY `created_at` timestamp(6) not null d
 alter table `avm_outputs_redeeming`  MODIFY `redeemed_at` timestamp(6) not null default current_timestamp(6);
 alter table `pvm_blocks`  MODIFY `created_at` timestamp(6) not null default current_timestamp(6);
 alter table `avm_assets`  MODIFY `created_at` timestamp(6) not null default current_timestamp(6);
-alter table `cvm_transactions`  MODIFY `created_at` timestamp(6) not null default current_timestamp(6);
+alter table `cvm_transactions_atomic`  MODIFY `created_at` timestamp(6) not null default current_timestamp(6);
 alter table `cvm_blocks`  MODIFY `created_at` timestamp(6) not null default current_timestamp(6);
 alter table `cvm_addresses`  MODIFY `created_at` timestamp(6) not null default current_timestamp(6);
 alter table `address_chain`  MODIFY `created_at` timestamp(6) not null default current_timestamp(6);
@@ -17,5 +17,4 @@ alter table `transactions_epoch`  MODIFY `created_at` timestamp(6) not null defa
 alter table `transactions_block`  MODIFY `created_at` timestamp(6) not null default current_timestamp(6);
 alter table `transactions_validator`  MODIFY `created_at` timestamp(6) not null default current_timestamp(6);
 
-alter table `cvm_transactions` add column `serialization` mediumblob;
-create index cvm_transactions_block ON cvm_transactions (block);
+create index cvm_transactions_atomic_block ON cvm_transactions_atomic (block);

--- a/services/db/migrations/026_cvm.down.sql
+++ b/services/db/migrations/026_cvm.down.sql
@@ -1,2 +1,0 @@
-drop index cvm_transactions_transaction_id ON cvm_transactions;
-alter table `cvm_transactions` drop column `transaction_id`;

--- a/services/db/migrations/026_cvm.up.sql
+++ b/services/db/migrations/026_cvm.up.sql
@@ -1,2 +1,0 @@
-alter table `cvm_transactions` add column `transaction_id` varchar(50) not null default '';
-create index cvm_transactions_transaction_id ON cvm_transactions (transaction_id);

--- a/services/db/migrations/028_cchain_tx.up.sql
+++ b/services/db/migrations/028_cchain_tx.up.sql
@@ -14,11 +14,3 @@ create table `cvm_transactions_txdata`
 create index cvm_transactions_txdata_hash ON cvm_transactions_txdata (hash);
 create index cvm_transactions_txdata_from ON cvm_transactions_txdata (from_addr);
 create index cvm_transactions_txdata_to ON cvm_transactions_txdata (to_addr);
-
-alter table `cvm_transactions` add COLUMN `tx_time` timestamp(6) not null default current_timestamp(6);
-alter table `cvm_transactions` add COLUMN `nonce` bigint unsigned not null default 0;
-alter table `cvm_transactions` add COLUMN `hash` varchar(100)    not null default '';
-alter table `cvm_transactions` add COLUMN `parent_hash` varchar(100)    not null default '';
-
-create index cvm_transactions_hash ON cvm_transactions (hash);
-create index cvm_transactions_parent_hash ON cvm_transactions (parent_hash);

--- a/services/db/migrations/034_cchain_receipt.up.sql
+++ b/services/db/migrations/034_cchain_receipt.up.sql
@@ -1,6 +1,8 @@
 create table `cvm_transactions_receipts`
 (
     hash           varchar(100)    not null,
+    status         smallInt        unsigned not null default 0,
+    gas_used       bigInt          unsigned not null default 0,
     serialization  mediumblob,
     created_at     timestamp(6)    not null default current_timestamp(6),
     primary key(hash)

--- a/services/indexes/avax/reader_list_cblocks.go
+++ b/services/indexes/avax/reader_list_cblocks.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
+
+package avax
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/chain4travel/magellan/cfg"
+	"github.com/chain4travel/magellan/db"
+	"github.com/chain4travel/magellan/models"
+	"github.com/chain4travel/magellan/services/indexes/params"
+)
+
+func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (*models.CBlockList, error) {
+	fmtHex := func(n uint64) string { return "0x" + strconv.FormatUint(n, 16) }
+
+	dbRunner, err := r.conns.DB().NewSession("list_cblocks", cfg.RequestTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	result := models.CBlockList{}
+	err = dbRunner.Select("COUNT(block)").
+		From(db.TableCvmBlocks).
+		LoadOneContext(ctx, &result.BlockCount)
+	if err != nil {
+		return nil, err
+	}
+
+	err = dbRunner.Select("COUNT(hash)").
+		From(db.TableCvmTransactionsTxdata).
+		LoadOneContext(ctx, &result.TransactionCount)
+	if err != nil {
+		return nil, err
+	}
+
+	// Setp 1 get Block headers
+	if p.ListParams.Limit > 0 {
+		var blockList []*db.CvmBlocks
+
+		_, err = dbRunner.Select(
+			"evm_tx",
+			"atomic_tx",
+			"serialization",
+		).
+			From(db.TableCvmBlocks).
+			OrderDesc("block").
+			Limit(uint64(p.ListParams.Limit)).
+			Offset(uint64(p.ListParams.Offset)).
+			LoadContext(ctx, &blockList)
+		if err != nil {
+			return nil, err
+		}
+
+		result.Blocks = make([]*models.CBlockHeaderBase, len(blockList))
+		for i, block := range blockList {
+			err = json.Unmarshal(block.Serialization, &result.Blocks[i])
+			if err != nil {
+				return nil, err
+			}
+			result.Blocks[i].EvmTx = block.EvmTx
+			result.Blocks[i].AtomicTx = block.AtomicTx
+		}
+	}
+
+	// Setp 2 get Transactions
+	if p.TxLimit > 0 {
+		var txList []*struct {
+			Serialization []byte
+			CreatedAt     time.Time
+			FromAddr      string
+			Block         uint64
+			Idx           uint64
+			Status        uint16
+			GasUsed       uint64
+		}
+
+		_, err = dbRunner.Select(
+			db.TableCvmTransactionsTxdata+".serialization",
+			db.TableCvmTransactionsTxdata+".created_at",
+			"from_addr",
+			"block",
+			"idx",
+			"status",
+			"gas_used",
+		).
+			From(db.TableCvmTransactionsTxdata).
+			LeftJoin(db.TableCvmTransactionsReceipts, db.TableCvmTransactionsTxdata+".hash = "+db.TableCvmTransactionsReceipts+".hash").
+			OrderDesc("block").
+			OrderAsc("idx").
+			Limit(uint64(p.TxLimit)).
+			Offset(uint64(p.TxOffset)).
+			LoadContext(ctx, &txList)
+		if err != nil {
+			return nil, err
+		}
+
+		result.Transactions = make([]*models.CTransactionDataBase, len(txList))
+		for i, tx := range txList {
+			dest := &result.Transactions[i]
+			err = json.Unmarshal(tx.Serialization, dest)
+			if err != nil {
+				return nil, err
+			}
+			(*dest).Block = fmtHex(tx.Block)
+			(*dest).Index = fmtHex(tx.Idx)
+			(*dest).CreatedAt = fmtHex(uint64(tx.CreatedAt.Unix()))
+			(*dest).From = tx.FromAddr
+			(*dest).Status = fmtHex(uint64(tx.Status))
+			(*dest).GasUsed = fmtHex(tx.GasUsed)
+		}
+	}
+
+	return &result, nil
+}

--- a/services/indexes/avax/reader_list_txs.go
+++ b/services/indexes/avax/reader_list_txs.go
@@ -641,7 +641,7 @@ func collectCvmTransactions(ctx context.Context, dbRunner dbr.SessionRunner, txI
 	var cvmAddress []models.CvmOutput
 	_, err := dbRunner.Select(
 		"cvm_addresses.type",
-		"cvm_transactions.type as transaction_type",
+		"cvm_transactions_atomic.type as transaction_type",
 		"cvm_addresses.idx",
 		"cast(cvm_addresses.amount as char) as amount",
 		"cvm_addresses.nonce",
@@ -650,11 +650,11 @@ func collectCvmTransactions(ctx context.Context, dbRunner dbr.SessionRunner, txI
 		"cvm_addresses.address",
 		"cvm_addresses.asset_id",
 		"cvm_addresses.created_at",
-		"cvm_transactions.blockchain_id as chain_id",
-		"cvm_transactions.block",
+		"cvm_transactions_atomic.chain_id",
+		"cvm_transactions_atomic.block",
 	).
 		From("cvm_addresses").
-		Join("cvm_transactions", "cvm_addresses.transaction_id=cvm_transactions.transaction_id").
+		Join("cvm_transactions_atomic", "cvm_addresses.transaction_id=cvm_transactions_atomic.transaction_id").
 		Where("cvm_addresses.transaction_id IN ?", txIDs).
 		LoadContext(ctx, &cvmAddress)
 	if err != nil {

--- a/services/indexes/avax/reader_test.go
+++ b/services/indexes/avax/reader_test.go
@@ -153,7 +153,7 @@ func TestAggregateTxfee(t *testing.T) {
 		Txfee:     10,
 		CreatedAt: tnow,
 	}
-	_ = persist.InsertTransactions(ctx, sess, transaction, false)
+	_ = persist.InsertTransactionsAtomic(ctx, sess, transaction, false)
 
 	transaction = &db.Transactions{
 		ID:        "id2",
@@ -162,7 +162,7 @@ func TestAggregateTxfee(t *testing.T) {
 		Txfee:     15,
 		CreatedAt: tnow.Add(-1 * time.Hour),
 	}
-	_ = persist.InsertTransactions(ctx, sess, transaction, false)
+	_ = persist.InsertTransactionsAtomic(ctx, sess, transaction, false)
 
 	starttime := tnow.Add(-2 * time.Hour)
 	endtime := tnow.Add(1 * time.Second)

--- a/services/indexes/avax/writer.go
+++ b/services/indexes/avax/writer.go
@@ -171,7 +171,7 @@ func (w *Writer) InsertTransactionBase(
 		NetworkID:              networkID,
 	}
 
-	return ctx.Persist().InsertTransactions(ctx.Ctx(), ctx.DB(), t, cfg.PerformUpdates)
+	return ctx.Persist().InsertTransactionsAtomic(ctx.Ctx(), ctx.DB(), t, cfg.PerformUpdates)
 }
 
 func (w *Writer) InsertTransactionIns(

--- a/services/indexes/avm/avm_test.go
+++ b/services/indexes/avm/avm_test.go
@@ -78,9 +78,9 @@ func TestIndexBootstrap(t *testing.T) {
 	transaction := &db.Transactions{
 		ID: string(txList.Transactions[0].ID),
 	}
-	transaction, _ = persist.QueryTransactions(context.Background(), session, transaction)
+	transaction, _ = persist.QueryTransactionsAtomic(context.Background(), session, transaction)
 	transaction.Txfee = 101
-	_ = persist.InsertTransactions(context.Background(), session, transaction, true)
+	_ = persist.InsertTransactionsAtomic(context.Background(), session, transaction, true)
 
 	txList, _ = reader.ListTransactions(context.Background(), &params.ListTransactionsParams{
 		ChainIDs: []string{string(txList.Transactions[0].ChainID)},
@@ -206,7 +206,7 @@ func TestInsertTxInternal(t *testing.T) {
 
 	persist := db.NewPersistMock()
 	session, _ := conns.DB().NewSession("avm_test_tx", cfg.RequestTimeout)
-	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist)
+	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist, testXChainID.String())
 	err := writer.insertTxInternal(cCtx, tx, tx.Bytes())
 	if err != nil {
 		t.Fatal("insert failed", err)
@@ -260,7 +260,7 @@ func TestInsertTxInternalCreateAsset(t *testing.T) {
 
 	persist := db.NewPersistMock()
 	session, _ := conns.DB().NewSession("avm_test_tx", cfg.RequestTimeout)
-	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist)
+	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist, testXChainID.String())
 	err := writer.insertTxInternal(cCtx, tx, tx.Bytes())
 	if err != nil {
 		t.Fatal("insert failed", err)
@@ -307,7 +307,7 @@ func TestTransactionNext(t *testing.T) {
 		ChainID:   "1",
 		CreatedAt: tnow1,
 	}
-	_ = persist.InsertTransactions(ctx, session, tx1, false)
+	_ = persist.InsertTransactionsAtomic(ctx, session, tx1, false)
 
 	tnow2 := tnow1.Add(time.Second)
 	tx2 := &db.Transactions{
@@ -315,7 +315,7 @@ func TestTransactionNext(t *testing.T) {
 		ChainID:   "1",
 		CreatedAt: tnow2,
 	}
-	_ = persist.InsertTransactions(ctx, session, tx2, false)
+	_ = persist.InsertTransactionsAtomic(ctx, session, tx2, false)
 
 	tnow3 := tnow2.Add(time.Second)
 	tx3 := &db.Transactions{
@@ -323,7 +323,7 @@ func TestTransactionNext(t *testing.T) {
 		ChainID:   "1",
 		CreatedAt: tnow3,
 	}
-	_ = persist.InsertTransactions(ctx, session, tx3, false)
+	_ = persist.InsertTransactionsAtomic(ctx, session, tx3, false)
 
 	tnow4 := tnow3.Add(time.Second)
 	tx4 := &db.Transactions{
@@ -331,7 +331,7 @@ func TestTransactionNext(t *testing.T) {
 		ChainID:   "1",
 		CreatedAt: tnow4,
 	}
-	_ = persist.InsertTransactions(ctx, session, tx4, false)
+	_ = persist.InsertTransactionsAtomic(ctx, session, tx4, false)
 
 	tp := params.ListTransactionsParams{}
 	_ = tp.ForValues(0, url.Values{})

--- a/services/indexes/avm/writer.go
+++ b/services/indexes/avm/writer.go
@@ -182,7 +182,7 @@ func (w *Writer) Bootstrap(ctx context.Context, conns *utils.Connections, persis
 
 		job := conns.Stream().NewJob("bootstrap")
 		dbSess := conns.DB().NewSessionForEventReceiver(job)
-		cCtx := services.NewConsumerContext(ctx, dbSess, int64(platformGenesis.Timestamp), 0, persist)
+		cCtx := services.NewConsumerContext(ctx, dbSess, int64(platformGenesis.Timestamp), 0, persist, w.chainID)
 		err = w.insertGenesis(cCtx, createChainTx.GenesisData)
 		if err != nil {
 			return err
@@ -221,7 +221,7 @@ func (w *Writer) ConsumeConsensus(ctx context.Context, conns *utils.Connections,
 	}
 	defer dbTx.RollbackUnlessCommitted()
 
-	cCtx := services.NewConsumerContext(ctx, dbTx, c.Timestamp(), c.Nanosecond(), persist)
+	cCtx := services.NewConsumerContext(ctx, dbTx, c.Timestamp(), c.Nanosecond(), persist, c.ChainID())
 
 	for _, tx := range txs {
 		var txID ids.ID
@@ -270,7 +270,7 @@ func (w *Writer) Consume(ctx context.Context, conns *utils.Connections, i servic
 	defer dbTx.RollbackUnlessCommitted()
 
 	// Ingest the tx and commit
-	err = w.insertTx(services.NewConsumerContext(ctx, dbTx, i.Timestamp(), i.Nanosecond(), persist), i.Body())
+	err = w.insertTx(services.NewConsumerContext(ctx, dbTx, i.Timestamp(), i.Nanosecond(), persist, i.ChainID()), i.Body())
 	if err != nil {
 		return err
 	}

--- a/services/indexes/cvm/cvm_test.go
+++ b/services/indexes/cvm/cvm_test.go
@@ -80,16 +80,16 @@ func TestInsertTxInternalExport(t *testing.T) {
 
 	tx.UnsignedAtomicTx = extx
 	header := types.Header{}
-	block := &modelsc.Block{Header: header}
+	block := &modelsc.Block{Header: header, BlockExtraData: tx.Bytes()}
 
 	persist := db.NewPersistMock()
 	session := conns.DB().NewSessionForEventReceiver(conns.Stream().NewJob("test_tx"))
-	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist)
-	err := writer.indexBlockInternal(cCtx, []*evm.Tx{tx}, tx.Bytes(), block)
+	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist, testXChainID.String())
+	err := writer.indexBlockInternal(cCtx, []*evm.Tx{tx}, block)
 	if err != nil {
 		t.Fatal("insert failed", err)
 	}
-	if len(persist.CvmTransactions) != 1 {
+	if len(persist.CvmTransactionsAtomic) != 1 {
 		t.Fatal("insert failed")
 	}
 	if len(persist.Outputs) != 1 {
@@ -112,16 +112,16 @@ func TestInsertTxInternalImport(t *testing.T) {
 
 	tx.UnsignedAtomicTx = extx
 	header := types.Header{}
-	block := &modelsc.Block{Header: header}
+	block := &modelsc.Block{Header: header, BlockExtraData: tx.Bytes()}
 
 	persist := db.NewPersistMock()
 	session := conns.DB().NewSessionForEventReceiver(conns.Stream().NewJob("test_tx"))
-	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist)
-	err := writer.indexBlockInternal(cCtx, []*evm.Tx{tx}, tx.Bytes(), block)
+	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist, testXChainID.String())
+	err := writer.indexBlockInternal(cCtx, []*evm.Tx{tx}, block)
 	if err != nil {
 		t.Fatal("insert failed", err)
 	}
-	if len(persist.CvmTransactions) != 1 {
+	if len(persist.CvmTransactionsAtomic) != 1 {
 		t.Fatal("insert failed")
 	}
 	if len(persist.CvmAddresses) != 1 {

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -43,6 +43,8 @@ var (
 	_ Param = &ListAssetsParams{}
 	_ Param = &ListAddressesParams{}
 	_ Param = &ListOutputsParams{}
+	_ Param = &ListCTransactionsParams{}
+	_ Param = &ListBlocksParams{}
 )
 
 type SearchParams struct {
@@ -332,6 +334,52 @@ func (p *ListCTransactionsParams) CacheKey() []string {
 func (p *ListCTransactionsParams) Apply(b *dbr.SelectBuilder) *dbr.SelectBuilder {
 	p.ListParams.ApplyPk(db.TableCvmTransactionsTxdata, b, "hash", false)
 
+	return b
+}
+
+type ListCBlocksParams struct {
+	ListParams ListParams
+	TxLimit    int
+	TxOffset   int
+}
+
+func (p *ListCBlocksParams) ForValues(version uint8, q url.Values) (err error) {
+	err = p.ListParams.ForValues(version, q)
+	if err != nil {
+		return err
+	}
+
+	p.TxLimit = 0
+	limits, ok := q[KeyLimit]
+	if ok && len(limits) > 1 {
+		if p.TxLimit, err = strconv.Atoi(limits[1]); err != nil {
+			return err
+		}
+	}
+
+	p.TxOffset = 0
+	offsets, ok := q[KeyOffset]
+	if ok && len(offsets) > 1 {
+		if p.TxOffset, err = strconv.Atoi(offsets[1]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *ListCBlocksParams) CacheKey() []string {
+	k := make([]string, 0, 2)
+
+	k = append(k,
+		CacheKey(KeyLimit, p.TxLimit),
+		CacheKey(KeyOffset, p.TxOffset),
+	)
+
+	return append(p.ListParams.CacheKey(), k...)
+}
+
+func (p *ListCBlocksParams) Apply(b *dbr.SelectBuilder) *dbr.SelectBuilder {
 	return b
 }
 

--- a/services/indexes/pvm/pvm_test.go
+++ b/services/indexes/pvm/pvm_test.go
@@ -98,7 +98,7 @@ func TestInsertTxInternal(t *testing.T) {
 
 	persist := db.NewPersistMock()
 	session, _ := conns.DB().NewSession("pvm_test_tx", cfg.RequestTimeout)
-	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist)
+	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist, testXChainID.String())
 	err := writer.indexTransaction(cCtx, tx.ID(), tx, false)
 	if err != nil {
 		t.Fatal("insert failed", err)
@@ -125,7 +125,7 @@ func TestInsertTxInternalRewards(t *testing.T) {
 
 	persist := db.NewPersistMock()
 	session, _ := conns.DB().NewSession("pvm_test_tx", cfg.RequestTimeout)
-	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist)
+	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist, testXChainID.String())
 	err := writer.indexTransaction(cCtx, tx.ID(), tx, false)
 	if err != nil {
 		t.Fatal("insert failed", err)
@@ -154,7 +154,7 @@ func TestCommonBlock(t *testing.T) {
 
 	persist := db.NewPersistMock()
 	session, _ := conns.DB().NewSession("pvm_test_tx", cfg.RequestTimeout)
-	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist)
+	cCtx := services.NewConsumerContext(ctx, session, time.Now().Unix(), 0, persist, testXChainID.String())
 	err := writer.indexCommonBlock(cCtx, blkid, models.BlockTypeCommit, tx, []byte(""))
 	if err != nil {
 		t.Fatal("insert failed", err)

--- a/services/indexes/pvm/writer.go
+++ b/services/indexes/pvm/writer.go
@@ -269,7 +269,7 @@ func (w *Writer) Consume(ctx context.Context, conns *utils.Connections, c servic
 	defer dbTx.RollbackUnlessCommitted()
 
 	// Consume the tx and commit
-	err = w.indexBlock(services.NewConsumerContext(ctx, dbTx, c.Timestamp(), c.Nanosecond(), persist), c.Body())
+	err = w.indexBlock(services.NewConsumerContext(ctx, dbTx, c.Timestamp(), c.Nanosecond(), persist, c.ChainID()), c.Body())
 	if err != nil {
 		return err
 	}
@@ -295,7 +295,7 @@ func (w *Writer) Bootstrap(ctx context.Context, conns *utils.Connections, persis
 		job  = conns.Stream().NewJob("bootstrap")
 		db   = conns.DB().NewSessionForEventReceiver(job)
 		errs = wrappers.Errs{}
-		cCtx = services.NewConsumerContext(ctx, db, int64(platformGenesis.Timestamp), 0, persist)
+		cCtx = services.NewConsumerContext(ctx, db, int64(platformGenesis.Timestamp), 0, persist, w.chainID)
 	)
 
 	for idx, utxo := range platformGenesis.UTXOs {

--- a/services/rewards/rewards_handler.go
+++ b/services/rewards/rewards_handler.go
@@ -57,7 +57,7 @@ func (r *Handler) runTicker(sc *servicesctrl.Control, conns *utils.Connections) 
 		sc.Log.Info("stop")
 	}()
 
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(24 * time.Hour)
 
 	r.doneCh = make(chan struct{}, 1)
 
@@ -177,7 +177,7 @@ func (r *Handler) processRewardUtxos(rewardsUtxos [][]byte, createdAt time.Time)
 			return err
 		}
 
-		cCtx := services.NewConsumerContext(ctx, sess, createdAt.Unix(), int64(createdAt.Nanosecond()), r.perist)
+		cCtx := services.NewConsumerContext(ctx, sess, createdAt.Unix(), int64(createdAt.Nanosecond()), r.perist, r.cid.String())
 
 		_, _, err = r.writer.ProcessStateOut(
 			cCtx,

--- a/services/services.go
+++ b/services/services.go
@@ -48,14 +48,16 @@ type ConsumerCtx struct {
 	db      dbr.SessionRunner
 	time    time.Time
 	persist db.Persist
+	chainID string
 }
 
-func NewConsumerContext(ctx context.Context, db dbr.SessionRunner, ts int64, nanosecond int64, persist db.Persist) ConsumerCtx {
+func NewConsumerContext(ctx context.Context, db dbr.SessionRunner, ts int64, nanosecond int64, persist db.Persist, chainID string) ConsumerCtx {
 	return ConsumerCtx{
 		ctx:     ctx,
 		db:      db,
 		time:    time.Unix(ts, nanosecond),
 		persist: persist,
+		chainID: chainID,
 	}
 }
 
@@ -63,3 +65,4 @@ func (ic *ConsumerCtx) Time() time.Time       { return ic.time }
 func (ic *ConsumerCtx) DB() dbr.SessionRunner { return ic.db }
 func (ic *ConsumerCtx) Ctx() context.Context  { return ic.ctx }
 func (ic *ConsumerCtx) Persist() db.Persist   { return ic.persist }
+func (ic *ConsumerCtx) ChainID() string       { return ic.chainID }

--- a/stream/consumer_cchain_db.go
+++ b/stream/consumer_cchain_db.go
@@ -187,7 +187,7 @@ func (c *consumerCChainDB) Consume(conns *utils.Connections, msg services.Consum
 	}
 
 	id := hashing.ComputeHash256(block.BlockExtraData)
-	nmsg := NewMessage(string(id), msg.ChainID(), block.BlockExtraData, msg.Timestamp(), msg.Nanosecond())
+	nmsg := NewMessage(string(id), msg.ChainID(), []byte{}, msg.Timestamp(), msg.Nanosecond())
 
 	rsleep := utils.NewRetrySleeper(1, 100*time.Millisecond, time.Second)
 	for {


### PR DESCRIPTION
Implement C-Chain request type for:
- latest Blocks (limit / offset)
- latest Transaction (limit / offset)

`Example: http://localhost:8080/v2/cblocks?limit=1&limit=2`
 queries the latest Block and the 2 latest Transaction

Note: Atomic TX are not yet supported, even the count of them is available in each block.

Example response:

```{
  "blockCount": 6,
  "transactionCount": 4,
  "blocks": [{
      "hash": "0x5250dbfb39fa3d6b7ef8c7eb9ef2917396c0c3627a63cb55d15ccc1cb5b73347",
      "miner": "0x0100000000000000000000000000000000000000",
      "difficulty": "0x1",
      "number": "0x5",
      "gasLimit": "0x7a1200",
      "gasUsed": "0xe34a",
      "timestamp": "0x624dca9b",
      "baseFeePerGas": "0x5d21dba00",
      "extDataGasUsed": "0x0",
      "blockGasCost": "0x0",
      "evmTx": 1
    }
  ],
  "transactions": [{
      "type": "0x0",
      "block": "0x5",
      "index": "0x0",
      "hash": "0x2b04a8e89e89e1f79e675589b34e94f67bd53af4bb3bc3e123c66ded24726c0e",
      "nonce": "0x3",
      "gasPrice": "0x746a52880",
      "gas": "0xfa05",
      "value": "0x0",
      "from": "0x0e455a324ea5eed5b08d477c9ab7b18c6ab8715c",
      "to": "0xb364f7079f08443c17624f3155f726f630a1ce45",
      "timestamp": "0x624dca9b",
      "status": "0x1",
      "gasUsed": "0xe34a"
    }, {
      "type": "0x2",
      "block": "0x4",
      "index": "0x0",
      "hash": "0x3af9fc482f216c1ca316f7c307c852a93391c326909b38fa7e9df1e9025d1563",
      "nonce": "0x2",
      "maxFeePerGas": "0xc393e6d00",
      "maxPriorityFeePerGas": "0x9502f900",
      "gas": "0xba48",
      "value": "0x0",
      "from": "0x0e455a324ea5eed5b08d477c9ab7b18c6ab8715c",
      "to": "0xb364f7079f08443c17624f3155f726f630a1ce45",
      "timestamp": "0x624d9c2e",
      "status": "0x1",
      "gasUsed": "0xba48"
    }
  ]
}
```