### PR TITLE
Cblocks

### DIFF
--- a/api/index.go
+++ b/api/index.go
@@ -25,9 +25,11 @@ const (
 	XChainAlias = "x"
 	PVMName     = "pvm"
 	PChainAlias = "p"
+	CVMName     = "cvm"
+	CChainAlias = "c"
 )
 
-func newIndexResponse(networkID uint32, xChainID ids.ID, avaxAssetID ids.ID) ([]byte, error) {
+func newIndexResponse(networkID uint32, xChainID, cChainID, avaxAssetID ids.ID) ([]byte, error) {
 	return json.Marshal(&struct {
 		NetworkID uint32                      `json:"network_id"`
 		Chains    map[string]models.ChainInfo `json:"chains"`
@@ -47,6 +49,13 @@ func newIndexResponse(networkID uint32, xChainID ids.ID, avaxAssetID ids.ID) ([]
 				NetworkID:   networkID,
 				AVAXAssetID: models.StringID(avaxAssetID.String()),
 				ID:          models.StringID(ids.Empty.String()),
+			},
+			cChainID.String(): {
+				VM:          CVMName,
+				Alias:       CChainAlias,
+				NetworkID:   networkID,
+				AVAXAssetID: models.StringID(avaxAssetID.String()),
+				ID:          models.StringID(cChainID.String()),
 			},
 		},
 	})

--- a/api/server.go
+++ b/api/server.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/chain4travel/caminogo/ids"
 	"github.com/chain4travel/magellan/cfg"
 	"github.com/chain4travel/magellan/models"
 	"github.com/chain4travel/magellan/services"
@@ -73,12 +74,31 @@ func (s *Server) Close() error {
 func newRouter(sc *servicesctrl.Control, conf cfg.Config) (*web.Router, error) {
 	sc.Log.Info("Router chainID %s", sc.GenesisContainer.XChainID.String())
 
-	indexBytes, err := newIndexResponse(conf.NetworkID, sc.GenesisContainer.XChainID, sc.GenesisContainer.AvaxAssetID)
+	var xChainID, cChainID ids.ID
+	for key, chain := range conf.Chains {
+		switch chain.VMType {
+		case models.CVMName:
+			cChainID, _ = ids.FromString(key)
+		case models.AVMName:
+			xChainID, _ = ids.FromString(key)
+		}
+	}
+
+	indexBytes, err := newIndexResponse(
+		conf.NetworkID,
+		xChainID,
+		cChainID,
+		sc.GenesisContainer.AvaxAssetID,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	legacyIndexResponse, err := newLegacyIndexResponse(conf.NetworkID, sc.GenesisContainer.XChainID, sc.GenesisContainer.AvaxAssetID)
+	legacyIndexResponse, err := newLegacyIndexResponse(
+		conf.NetworkID,
+		sc.GenesisContainer.XChainID,
+		sc.GenesisContainer.AvaxAssetID,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/services/db/migrations/045_block_idx_index.down.sql
+++ b/services/db/migrations/045_block_idx_index.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX cvm_transactions_txdata_block_idx on cvm_transactions_txdata;
+ALTER TABLE cvm_transactions_txdata DROP COLUMN block_idx;
+CREATE UNIQUE INDEX cvm_transactions_txdata_block ON cvm_transactions_txdata (block, idx);

--- a/services/db/migrations/045_block_idx_index.up.sql
+++ b/services/db/migrations/045_block_idx_index.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE cvm_transactions_txdata MODIFY block BigInt UNSIGNED NOT NULL;
+ALTER TABLE cvm_transactions_txdata MODIFY idx SmallInt UNSIGNED NOT NULL;
+DROP INDEX cvm_transactions_txdata_block on cvm_transactions_txdata;
+ALTER TABLE cvm_transactions_txdata ADD COLUMN block_idx BIGINT UNSIGNED GENERATED ALWAYS AS (BLOCK*1000 + cast(999 - cast(idx AS SIGNED) AS UNSIGNED)) STORED;
+CREATE UNIQUE INDEX cvm_transactions_txdata_block_idx ON cvm_transactions_txdata (block_idx);

--- a/services/indexes/avax/reader_list_cblocks.go
+++ b/services/indexes/avax/reader_list_cblocks.go
@@ -49,16 +49,26 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 	if p.ListParams.Limit > 0 {
 		var blockList []*db.CvmBlocks
 
-		_, err = dbRunner.Select(
+		sq := dbRunner.Select(
 			"evm_tx",
 			"atomic_tx",
 			"serialization",
 		).
 			From(db.TableCvmBlocks).
-			OrderDesc("block").
-			Limit(uint64(p.ListParams.Limit)).
-			Offset(uint64(p.ListParams.Offset)).
-			LoadContext(ctx, &blockList)
+			Limit(uint64(p.ListParams.Limit))
+
+		switch {
+		case p.BlockStart != nil:
+			sq = sq.OrderDesc("block").
+				Where("block < ?", p.BlockStart.Uint64())
+		case p.BlockEnd != nil:
+			sq = sq.OrderAsc("block").
+				Where("block > ?", p.BlockEnd.Uint64())
+		default:
+			sq = sq.OrderDesc("block")
+		}
+
+		_, err = sq.LoadContext(ctx, &blockList)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +97,7 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 			GasPrice      uint64
 		}
 
-		_, err = dbRunner.Select(
+		sq := dbRunner.Select(
 			"serialization",
 			"created_at",
 			"from_addr",
@@ -98,11 +108,21 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 			"gas_price",
 		).
 			From(db.TableCvmTransactionsTxdata).
-			OrderDesc("block").
-			OrderAsc("idx").
-			Limit(uint64(p.TxLimit)).
-			Offset(uint64(p.TxOffset)).
-			LoadContext(ctx, &txList)
+			OrderDesc("block_idx").
+			Limit(uint64(p.TxLimit))
+
+		switch {
+		case p.BlockStart != nil:
+			sq = sq.OrderDesc("block_idx").
+				Where("block_idx < ?", p.BlockStart.Uint64()*1000+999-uint64(p.TxID))
+		case p.BlockEnd != nil:
+			sq = sq.OrderAsc("block_idx").
+				Where("block_idx > ?", p.BlockEnd.Uint64()*1000+999-uint64(p.TxID))
+		default:
+			sq = sq.OrderDesc("block_idx")
+		}
+
+		_, err = sq.LoadContext(ctx, &txList)
 		if err != nil {
 			return nil, err
 		}

--- a/services/indexes/avax/reader_list_cblocks.go
+++ b/services/indexes/avax/reader_list_cblocks.go
@@ -60,10 +60,10 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 		switch {
 		case p.BlockStart != nil:
 			sq = sq.OrderDesc("block").
-				Where("block < ?", p.BlockStart.Uint64())
+				Where("block <= ?", p.BlockStart.Uint64())
 		case p.BlockEnd != nil:
 			sq = sq.OrderAsc("block").
-				Where("block > ?", p.BlockEnd.Uint64())
+				Where("block >= ?", p.BlockEnd.Uint64())
 		default:
 			sq = sq.OrderDesc("block")
 		}
@@ -114,10 +114,10 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 		switch {
 		case p.BlockStart != nil:
 			sq = sq.OrderDesc("block_idx").
-				Where("block_idx < ?", p.BlockStart.Uint64()*1000+999-uint64(p.TxID))
+				Where("block_idx <= ?", p.BlockStart.Uint64()*1000+999-uint64(p.TxID))
 		case p.BlockEnd != nil:
 			sq = sq.OrderAsc("block_idx").
-				Where("block_idx > ?", p.BlockEnd.Uint64()*1000+999-uint64(p.TxID))
+				Where("block_idx >= ?", p.BlockEnd.Uint64()*1000+999-uint64(p.TxID))
 		default:
 			sq = sq.OrderDesc("block_idx")
 		}

--- a/services/indexes/cvm/writer.go
+++ b/services/indexes/cvm/writer.go
@@ -236,7 +236,7 @@ func (w *Writer) indexBlockInternal(ctx services.ConsumerCtx, atomicTXs []*evm.T
 		}
 
 		if w.client != nil {
-			receipt, err := w.client.ReadReceipt(hash, time.Millisecond*500)
+			receipt, err := w.client.ReadReceipt(hash, time.Second*1)
 			if err != nil {
 				return err
 			}

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -260,12 +260,7 @@ type ListCTransactionsParams struct {
 }
 
 func (p *ListCTransactionsParams) ForValues(v uint8, q url.Values) error {
-	err := p.ListParams.ForValuesAllowOffset(v, q)
-	if err != nil {
-		return err
-	}
-
-	err = p.ListParams.ForValues(v, q)
+	err := p.ListParams.ForValues(v, q)
 	if err != nil {
 		return err
 	}
@@ -346,6 +341,9 @@ type ListCBlocksParams struct {
 	ListParams ListParams
 	TxLimit    int
 	TxOffset   int
+	BlockStart *big.Int
+	BlockEnd   *big.Int
+	TxID       uint
 }
 
 func (p *ListCBlocksParams) ForValues(version uint8, q url.Values) (err error) {
@@ -362,14 +360,29 @@ func (p *ListCBlocksParams) ForValues(version uint8, q url.Values) (err error) {
 		}
 	}
 
-	p.TxOffset = 0
-	offsets, ok := q[KeyOffset]
-	if ok && len(offsets) > 1 {
-		if p.TxOffset, err = strconv.Atoi(offsets[1]); err != nil {
-			return err
+	blockStartStr := q[KeyBlockStart]
+	if len(blockStartStr) == 1 {
+		bint := big.NewInt(0)
+		if _, ok := bint.SetString(blockStartStr[0], 10); ok {
+			p.BlockStart = bint
+		}
+	}
+	blockEndStr := q[KeyBlockEnd]
+	if len(blockEndStr) == 1 {
+		bint := big.NewInt(0)
+		if _, ok := bint.SetString(blockEndStr[0], 10); ok {
+			p.BlockStart = bint
 		}
 	}
 
+	txIDs := q[KeyTransactionID]
+	if len(txIDs) == 1 {
+		txID, err := strconv.ParseInt(txIDs[0], 10, 32)
+		if err != nil {
+			return err
+		}
+		p.TxID = uint(txID)
+	}
 	return nil
 }
 

--- a/services/indexes/params/params.go
+++ b/services/indexes/params/params.go
@@ -46,6 +46,7 @@ const (
 	KeyDisableGenesis   = "disableGenesis"
 	KeyOutputOutputType = "outputOutputType"
 	KeyOutputGroupID    = "outputGroupId"
+	KeyTransactionID    = "transactionId"
 
 	PaginationMaxLimit      = 5000
 	PaginationDefaultOffset = 0


### PR DESCRIPTION
### CBlocks chunks: remove offset / use block (+transactionIdx)

Requesting with "offset" does not really work with result sets which change every second.
Because of this this PR removes the "offset" capability for the cblocks query and implements blockStart / blockEnd and transactionId parameters:

* If neither blockStart nor blockEnd is passed, the latest blocks / transactions are returned in desc order.
* If blockStart is passed, "older" results are returned, a desc sorted resultset is returned starting at blockstart (and for tx at transactionId)
* if blockEnd is passed, newer results are returned, ending at blockEnd (and for TX transactionId)

### Aggregate + TxfeeAggregate for C-Chain
This PR adds collecting txfees, transferVolume and txCount for the c-chain.
If chainId paramater is not passed, aggregation runs over all existing chains.

The /v2 call now returnes the chain-id for the c-chain, too to let UI filter for c-aggregates only
