### PR TITLE
Use raw bytes instead re-marshalled receipt

### DIFF
--- a/modelsc/cclient.go
+++ b/modelsc/cclient.go
@@ -69,6 +69,8 @@ type ExtendedReceipt struct {
 	BlockNumber *big.Int    `json:"blockNumber,omitempty"`
 
 	EffectiveGasPrice uint64 `json:"effectiveGasPrice"`
+
+	Raw []byte `json:"-"`
 }
 
 // UnmarshalJSON unmarshals from JSON.
@@ -136,6 +138,7 @@ func (r *ExtendedReceipt) UnmarshalJSON(input []byte) error {
 	if dec.EffectiveGasPrice != nil {
 		r.EffectiveGasPrice = uint64(*dec.EffectiveGasPrice)
 	}
+	r.Raw = input
 	return nil
 }
 

--- a/services/indexes/cvm/writer.go
+++ b/services/indexes/cvm/writer.go
@@ -240,15 +240,11 @@ func (w *Writer) indexBlockInternal(ctx services.ConsumerCtx, atomicTXs []*evm.T
 			if err != nil {
 				return err
 			}
-			receiptBits, err := json.Marshal(receipt)
-			if err != nil {
-				return err
-			}
 
 			cvmTransactionTxdata.Status = uint16(receipt.Status)
 			cvmTransactionTxdata.GasPrice = receipt.EffectiveGasPrice
 			cvmTransactionTxdata.GasUsed = receipt.GasUsed
-			cvmTransactionTxdata.Receipt = receiptBits
+			cvmTransactionTxdata.Receipt = receipt.Raw
 		}
 
 		err = ctx.Persist().InsertCvmTransactionsTxdata(ctx.Ctx(), ctx.DB(), cvmTransactionTxdata, cfg.PerformUpdates)


### PR DESCRIPTION
Right now TxReceipts are fetched through rpc/json, unmarshalled during api call, and again marshalled when writing into serialization db field.

This PR holds the raw json from api call and writes it directly into db avoiding a separate marshall step.