### PR TITLE
Add cvm_accounts table

### DIFF
--- a/db/dbmodel_mock.go
+++ b/db/dbmodel_mock.go
@@ -17,6 +17,7 @@ type MockPersist struct {
 	OutputsRedeeming                 map[string]*OutputsRedeeming
 	CvmTransactionsAtomic            map[string]*CvmTransactionsAtomic
 	CvmTransactionsTxdata            map[string]*CvmTransactionsTxdata
+	CvmAccounts                      map[string]*CvmAccount
 	CvmBlocks                        map[string]*CvmBlocks
 	CvmAddresses                     map[string]*CvmAddresses
 	TransactionsValidator            map[string]*TransactionsValidator
@@ -50,6 +51,7 @@ func NewPersistMock() *MockPersist {
 		OutputsRedeeming:                 make(map[string]*OutputsRedeeming),
 		CvmTransactionsAtomic:            make(map[string]*CvmTransactionsAtomic),
 		CvmTransactionsTxdata:            make(map[string]*CvmTransactionsTxdata),
+		CvmAccounts:                      make(map[string]*CvmAccount),
 		CvmBlocks:                        make(map[string]*CvmBlocks),
 		CvmAddresses:                     make(map[string]*CvmAddresses),
 		TransactionsValidator:            make(map[string]*TransactionsValidator),
@@ -299,6 +301,24 @@ func (m *MockPersist) InsertCvmTransactionsTxdata(ctx context.Context, runner db
 	nv := &CvmTransactionsTxdata{}
 	*nv = *v
 	m.CvmTransactionsTxdata[v.Hash] = nv
+	return nil
+}
+
+func (m *MockPersist) QueryCvmAccount(ctx context.Context, runner dbr.SessionRunner, v *CvmAccount) (*CvmAccount, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if v, present := m.CvmAccounts[v.Address]; present {
+		return v, nil
+	}
+	return nil, nil
+}
+
+func (m *MockPersist) InsertCvmAccount(ctx context.Context, runner dbr.SessionRunner, v *CvmAccount, b bool) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	nv := &CvmAccount{}
+	*nv = *v
+	m.CvmAccounts[v.Address] = nv
 	return nil
 }
 

--- a/db/dbmodel_test.go
+++ b/db/dbmodel_test.go
@@ -724,6 +724,10 @@ func TestCvmTransactionsTxdata(t *testing.T) {
 	}
 	_, _ = rawDBConn.NewSession(stream).DeleteFrom(TableCvmTransactionsTxdata).Exec()
 
+	err = p.InsertCvmAccount(ctx, rawDBConn.NewSession(stream), &CvmAccount{}, true)
+	if err != nil {
+		t.Fatal("insert fail", err)
+	}
 	err = p.InsertCvmTransactionsTxdata(ctx, rawDBConn.NewSession(stream), v, true)
 	if err != nil {
 		t.Fatal("insert fail", err)

--- a/modelsc/cclient.go
+++ b/modelsc/cclient.go
@@ -57,9 +57,9 @@ type ExtendedReceipt struct {
 
 	// Implementation fields: These fields are added by geth when processing a transaction.
 	// They are stored in the chain database.
-	TxHash           common.Hash    `json:"transactionHash" gencodec:"required"`
-	ContractAddress  common.Address `json:"contractAddress"`
-	TransactionIndex uint           `json:"transactionIndex"`
+	TxHash           common.Hash     `json:"transactionHash" gencodec:"required"`
+	ContractAddress  *common.Address `json:"contractAddress"`
+	TransactionIndex uint            `json:"transactionIndex"`
 
 	GasUsed uint64 `json:"gasUsed" gencodec:"required"`
 
@@ -119,9 +119,7 @@ func (r *ExtendedReceipt) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'transactionHash' for Receipt")
 	}
 	r.TxHash = *dec.TxHash
-	if dec.ContractAddress != nil {
-		r.ContractAddress = *dec.ContractAddress
-	}
+	r.ContractAddress = dec.ContractAddress
 	if dec.GasUsed == nil {
 		return errors.New("missing required field 'gasUsed' for Receipt")
 	}

--- a/services/db/migrations/047_c_accounts.down.sql
+++ b/services/db/migrations/047_c_accounts.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE cvm_transactions_txdata ADD COLUMN from_addr varchar(50) AFTER id_from_addr, ADD COLUMN to_addr varchar(50) AFTER id_to_addr;
+UPDATE cvm_transactions_txdata, cvm_accounts SET from_addr = address WHERE id_from_addr = id;
+UPDATE cvm_transactions_txdata, cvm_accounts SET to_addr = address WHERE id_to_addr = id;
+
+DROP TABLE cvm_accounts;
+
+ALTER TABLE cvm_transactions_txdata DROP INDEX ctx_id_from_addr, DROP INDEX ctx_id_to_addr;
+ALTER TABLE cvm_transactions_txdata DROP COLUMN id_from_addr, DROP COLUMN id_to_addr;
+CREATE INDEX cvm_transactions_txdata_from on cvm_transactions_txdata(from_addr);
+CREATE INDEX cvm_transactions_txdata_to on cvm_transactions_txdata(to_addr);

--- a/services/db/migrations/047_c_accounts.up.sql
+++ b/services/db/migrations/047_c_accounts.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE cvm_accounts (address CHAR(42), tx_count BIGINT UNSIGNED NOT NULL DEFAULT 0, creation_tx char(66));
+CREATE UNIQUE INDEX cvm_accounts_address ON cvm_accounts (address);
+
+INSERT INTO cvm_accounts (address, creation_tx) SELECT JSON_VALUE(CONVERT(receipt USING utf8mb4), '$.contractAddress'), hash from cvm_transactions_txdata WHERE NULLIF(to_addr,"") IS NULL;
+INSERT INTO cvm_accounts (address,tx_count) SELECT * FROM(SELECT from_addr, COUNT(from_addr) as count from cvm_transactions_txdata GROUP by from_addr) AS N ON DUPLICATE KEY UPDATE tx_count=tx_count+N.count;
+INSERT INTO cvm_accounts (address,tx_count) SELECT * FROM(SELECT NULLIF(to_addr,"") AS T, COUNT(COALESCE(to_addr,"")) as count from cvm_transactions_txdata WHERE from_addr != COALESCE(to_addr,"") GROUP by T) AS N ON DUPLICATE KEY UPDATE tx_count=tx_count+N.count;
+ALTER TABLE cvm_accounts ADD id BigInt UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+
+ALTER TABLE cvm_transactions_txdata ADD COLUMN id_from_addr BIGINT UNSIGNED NOT NULL DEFAULT 0 AFTER from_addr, ADD COLUMN id_to_addr BIGINT UNSIGNED NOT NULL DEFAULT 0 AFTER to_addr;
+UPDATE cvm_transactions_txdata, cvm_accounts SET id_from_addr = id WHERE from_addr = address;
+UPDATE cvm_transactions_txdata, cvm_accounts SET id_to_addr = id WHERE to_addr = address;
+ALTER TABLE cvm_transactions_txdata DROP INDEX cvm_transactions_txdata_from, DROP INDEX cvm_transactions_txdata_to;
+ALTER TABLE cvm_transactions_txdata DROP COLUMN from_addr, DROP COLUMN to_addr;
+CREATE INDEX ctx_id_from_addr on cvm_transactions_txdata(id_from_addr);
+CREATE INDEX ctx_id_to_addr on cvm_transactions_txdata(id_to_addr);

--- a/utils/db.go
+++ b/utils/db.go
@@ -27,7 +27,7 @@ import (
 const (
 	DriverMysql     = "mysql"
 	DriverNone      = ""
-	RequiredVersion = 44
+	RequiredVersion = 47
 )
 
 // Conn is a wrapper around a dbr connection and a health stream


### PR DESCRIPTION
Implementation of cvm_accounts table:

```+-------------+-----------------+------+-----+---------+----------------+
| Field       | Type            | Null | Key | Default | Extra          |
+-------------+-----------------+------+-----+---------+----------------+
| id          | bigint unsigned | NO   | PRI | NULL    | auto_increment |
| address     | char(42)        | YES  | UNI | NULL    |                |
| tx_count    | bigint unsigned | NO   |     | 0       |                |
| creation_tx | char(66)        | YES  |     | NULL    |                |
+-------------+-----------------+------+-----+---------+----------------+
```
`tx_count` accumulates tx which are send from or to address
`creation_tx`: the tx hash which deployed the SC in case the address is a smart contract

`cvm_accounts` is used in cblocks query to return the overall number of tx of an address (from or to)
