### PR TITLE
Use block_idx instead block for filter

### DIFF
--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -1257,9 +1257,8 @@ func (r *Reader) CTxDATA(ctx context.Context, p *params.TxDataParam) ([]byte, er
 	idInt, ok := big.NewInt(0).SetString(p.ID, 10)
 	if !ok {
 		err = dbRunner.
-			Select("MAX(id)").
+			Select("MAX(block)").
 			From(db.TableCvmBlocks).
-			Where("block="+idInt.String()).
 			Limit(1).
 			LoadOneContext(ctx, &idInt)
 		if err != nil {

--- a/services/indexes/avax/reader_list_ctrans.go
+++ b/services/indexes/avax/reader_list_ctrans.go
@@ -13,6 +13,7 @@ package avax
 import (
 	"context"
 	"encoding/hex"
+	"math/big"
 	"strings"
 	"time"
 
@@ -159,10 +160,13 @@ func (r *Reader) listCTransFilter(p *params.ListCTransactionsParams, dbRunner *d
 			return b
 		}
 		if p.BlockStart != nil {
-			b.Where(db.TableCvmTransactionsTxdata + ".block >= " + p.BlockStart.String())
+			blockStart := new(big.Int).Mul(p.BlockStart, big.NewInt(1000))
+			b.Where(db.TableCvmTransactionsTxdata + ".block_idx >= " + blockStart.String())
 		}
 		if p.BlockEnd != nil {
-			b.Where(db.TableCvmTransactionsTxdata + ".block <= " + p.BlockEnd.String())
+			blockEnd := new(big.Int).Add(p.BlockEnd, big.NewInt(1))
+			blockEnd.Mul(blockEnd, big.NewInt(1000))
+			b.Where(db.TableCvmTransactionsTxdata + ".block_idx < " + blockEnd.String())
 		}
 		return b
 	}


### PR DESCRIPTION
When querying ctxData (for transaction details) the SQL query filters on cvm_transactions_txdata::block which is not indexed.
Queries tke in general too long and run into deadline.

This PR changes the filter to block_idx field which is indexed and therefore fast.