### PR TITLE
Feature/tech 179 caching mechanism

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_PASS }}
       - name: Push to Docker Hub
         uses: docker/build-push-action@v2
         with:

--- a/api/server.go
+++ b/api/server.go
@@ -19,13 +19,13 @@ import (
 	"time"
 
 	"github.com/chain4travel/caminogo/ids"
+	"github.com/chain4travel/magellan/caching"
 	"github.com/chain4travel/magellan/cfg"
 	"github.com/chain4travel/magellan/models"
 	"github.com/chain4travel/magellan/services"
 	"github.com/chain4travel/magellan/services/indexes/avax"
 	"github.com/chain4travel/magellan/servicesctrl"
 	"github.com/chain4travel/magellan/stream/consumers"
-	"github.com/chain4travel/magellan/utils"
 	"github.com/gocraft/web"
 )
 
@@ -109,8 +109,8 @@ func newRouter(sc *servicesctrl.Control, conf cfg.Config) (*web.Router, error) {
 		return nil, err
 	}
 
-	cache := utils.NewCache()
-	delayCache := utils.NewDelayCache(cache)
+	cache := caching.NewCache()
+	delayCache := caching.NewDelayCache(cache)
 
 	consumersmap := make(map[string]services.Consumer)
 	for chid, chain := range conf.Chains {

--- a/caching/aggregates_cache.go
+++ b/caching/aggregates_cache.go
@@ -1,0 +1,569 @@
+package caching
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net/url"
+	"time"
+
+	"github.com/chain4travel/magellan/cfg"
+	"github.com/chain4travel/magellan/models"
+	"github.com/chain4travel/magellan/services/indexes/params"
+	"github.com/chain4travel/magellan/utils"
+	"github.com/gocraft/dbr/v2"
+)
+
+const (
+	MaxAggregateIntervalCount = 20000
+)
+
+var (
+	ErrAggregateIntervalCountTooLarge = errors.New("requesting too many intervals")
+	ErrFailedToParseStringAsBigInt    = errors.New("failed to parse string to big.Int")
+)
+
+type AggregatesCache interface {
+	GetAggregateTransactionsMap() map[string]map[string]uint64
+	GetAggregateFeesMap() map[string]map[string]uint64
+	InitCacheStorage(cfg.Chains)
+	GetAggregatesFeesAndUpdate(map[string]cfg.Chain, *utils.Connections, string, time.Time, time.Time, string) error
+	GetAggregatesAndUpdate(map[string]cfg.Chain, *utils.Connections, string, time.Time, time.Time, string) error
+}
+
+type aggregatesCache struct {
+	aggregateTransactionsMap map[string]map[string]uint64
+	aggregateFeesMap         map[string]map[string]uint64
+}
+
+func NewAggregatesCache() AggregatesCache {
+	return &aggregatesCache{
+		aggregateTransactionsMap: make(map[string]map[string]uint64),
+		aggregateFeesMap:         make(map[string]map[string]uint64),
+	}
+}
+
+func (ac *aggregatesCache) GetAggregateTransactionsMap() map[string]map[string]uint64 {
+	return ac.aggregateTransactionsMap
+}
+
+func (ac *aggregatesCache) GetAggregateFeesMap() map[string]map[string]uint64 {
+	return ac.aggregateFeesMap
+}
+
+func (ac *aggregatesCache) InitCacheStorage(chains cfg.Chains) {
+	aggregateTransMap := ac.aggregateTransactionsMap
+	aggregateFeesMap := ac.aggregateFeesMap
+	for id := range chains {
+		aggregateTransMap[id] = map[string]uint64{}
+		aggregateFeesMap[id] = map[string]uint64{}
+
+		// we initialize the value for all 3 chains
+		aggregateTransMap[id]["day"] = 0
+		aggregateTransMap[id]["week"] = 0
+		aggregateTransMap[id]["month"] = 0
+
+		// we initialize the value for all 3 chains also here
+		aggregateFeesMap[id]["day"] = 0
+		aggregateFeesMap[id]["week"] = 0
+		aggregateFeesMap[id]["month"] = 0
+	}
+}
+
+func (ac *aggregatesCache) GetAggregatesAndUpdate(chains map[string]cfg.Chain, conns *utils.Connections, chainid string, startTime time.Time, endTime time.Time, rangeKeyType string) error {
+	chainIds := []string{chainid}
+	// Validate params and set defaults if necessary
+	if startTime.IsZero() {
+		var err error
+		startTime, err = getFirstTransactionTime(conns, chainIds)
+		if err != nil {
+			return err
+		}
+	}
+
+	intervals := models.AggregatesList{}
+	urlv := url.Values{}
+	assetId, err := params.GetQueryID(urlv, params.KeyAssetID)
+	if err != nil {
+		return err
+	}
+	intervalSize, err := params.GetQueryInterval(urlv, params.KeyIntervalSize)
+
+	// Ensure the interval count requested isn't too large
+	intervalSeconds := int64(intervalSize.Seconds())
+	requestedIntervalCount := 0
+	if intervalSeconds != 0 {
+		requestedIntervalCount = int(math.Ceil(endTime.Sub(startTime).Seconds() / intervalSize.Seconds()))
+		if requestedIntervalCount > MaxAggregateIntervalCount {
+			return ErrAggregateIntervalCountTooLarge
+		}
+		if requestedIntervalCount < 1 {
+			requestedIntervalCount = 1
+		}
+	}
+
+	// Split chains
+	var avmChains, cvmChains []string
+	if len(chainIds) == 0 {
+		for id, chain := range chains {
+			switch chain.VMType {
+			case models.CVMName:
+				cvmChains = append(cvmChains, id)
+			default:
+				avmChains = append(avmChains, id)
+			}
+		}
+	} else {
+		for _, id := range chainIds {
+			chain, exist := chains[id]
+			if exist {
+				switch chain.VMType {
+				case models.CVMName:
+					cvmChains = append(cvmChains, id)
+				default:
+					avmChains = append(avmChains, id)
+				}
+			}
+		}
+	}
+
+	var dbRunner *dbr.Session
+
+	if conns != nil {
+		dbRunner = conns.DB().NewSessionForEventReceiver(conns.Stream().NewJob("get_transaction_aggregates_histogram"))
+	} else {
+		dbRunner, err = conns.DB().NewSession("get_transaction_aggregates_histogram", cfg.RequestTimeout)
+		if err != nil {
+			return err
+		}
+	}
+
+	var builder *dbr.SelectStmt
+
+	if len(avmChains) > 0 {
+		columns := []string{
+			"COALESCE(SUM(avm_outputs.amount), 0) AS transaction_volume",
+			"COUNT(DISTINCT(avm_outputs.transaction_id)) AS transaction_count",
+			"COUNT(DISTINCT(avm_output_addresses.address)) AS address_count",
+			"COUNT(DISTINCT(avm_outputs.asset_id)) AS asset_count",
+			"COUNT(avm_outputs.id) AS output_count",
+		}
+
+		if requestedIntervalCount > 0 {
+			columns = append(columns, fmt.Sprintf(
+				"FLOOR((UNIX_TIMESTAMP(avm_outputs.created_at)-%d) / %d) AS interval_id",
+				startTime.Unix(),
+				intervalSeconds))
+		}
+
+		builder = dbRunner.
+			Select(columns...).
+			From("avm_outputs").
+			LeftJoin("avm_output_addresses", "avm_output_addresses.output_id = avm_outputs.id").
+			Where("avm_outputs.created_at >= ?", startTime).
+			Where("avm_outputs.created_at < ?", endTime)
+
+		if len(chainIds) != 0 {
+			builder.Where("avm_outputs.chain_id IN ?", avmChains)
+		}
+
+		if assetId != nil {
+			builder.Where("avm_outputs.asset_id = ?", assetId.String())
+		}
+
+		if requestedIntervalCount > 0 {
+			builder.
+				GroupBy("interval_id").
+				OrderAsc("interval_id").
+				Limit(uint64(requestedIntervalCount))
+		}
+
+		_, err = builder.Load(&intervals)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(cvmChains) > 0 {
+		columns := []string{
+			"COALESCE(SUM(cvm_transactions_txdata.amount), 0) AS transaction_volume",
+			"COUNT(cvm_transactions_txdata.hash) AS transaction_count",
+			"COUNT(DISTINCT(cvm_transactions_txdata.id_from_addr)) AS address_count",
+			"1 AS asset_count",
+			"0 AS output_count",
+		}
+
+		if requestedIntervalCount > 0 {
+			columns = append(columns, fmt.Sprintf(
+				"FLOOR((UNIX_TIMESTAMP(cvm_transactions_txdata.created_at)-%d) / %d) AS interval_id",
+				startTime.Unix(),
+				intervalSeconds))
+		}
+
+		builder = dbRunner.
+			Select(columns...).
+			From("cvm_transactions_txdata")
+
+		if len(chainIds) != 0 {
+			builder.Join("cvm_blocks", "cvm_blocks.block = cvm_transactions_txdata.block").
+				Where("cvm_blocks.chain_id IN ?", cvmChains)
+		}
+
+		builder.Where("cvm_transactions_txdata.created_at >= ?", startTime).
+			Where("cvm_transactions_txdata.created_at < ?", endTime)
+
+		if requestedIntervalCount > 0 {
+			builder.
+				GroupBy("interval_id").
+				OrderAsc("interval_id").
+				Limit(uint64(requestedIntervalCount))
+		}
+
+		cvmIntervals := models.AggregatesList{}
+
+		_, err = builder.Load(&cvmIntervals)
+		if err != nil {
+			return err
+		}
+
+		if len(intervals) == 0 {
+			intervals = cvmIntervals
+		} else {
+			models.MergeAggregates(intervals.MergeList(), cvmIntervals.MergeList())
+		}
+	}
+
+	// If no intervals were requested then the total aggregate is equal to the
+	// first (and only) interval, and we're done
+	if requestedIntervalCount == 0 {
+		// This check should never fail if the SQL query is correct, but added for
+		// robustness to prevent panics if the invariant does not hold.
+		if len(intervals) > 0 {
+			intervals[0].StartTime = startTime
+			intervals[0].EndTime = endTime
+			aggs := &models.AggregatesHistogram{
+				Aggregates: intervals[0],
+				StartTime:  startTime,
+				EndTime:    endTime,
+			}
+			ac.aggregateTransactionsMap[chainid][rangeKeyType] = aggs.Aggregates.TransactionCount
+			return nil
+		}
+		aggs := &models.AggregatesHistogram{
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+		ac.aggregateTransactionsMap[chainid][rangeKeyType] = aggs.Aggregates.TransactionCount
+		return nil
+	}
+
+	// We need to return multiple intervals so build them now.
+	// Intervals without any data will not return anything so we pad our results
+	// with empty aggregates.
+	//
+	// We also add the start and end times of each interval to that interval
+	aggs := &models.AggregatesHistogram{IntervalSize: intervalSize}
+
+	var startTS int64
+	timesForInterval := func(intervalIdx int) (time.Time, time.Time) {
+		startTS = startTime.Unix() + (int64(intervalIdx) * intervalSeconds)
+		return time.Unix(startTS, 0).UTC(),
+			time.Unix(startTS+intervalSeconds-1, 0).UTC()
+	}
+
+	padTo := func(slice []models.Aggregates, to int) []models.Aggregates {
+		for i := len(slice); i < to; i = len(slice) {
+			slice = append(slice, models.Aggregates{IntervalID: i})
+			slice[i].StartTime, slice[i].EndTime = timesForInterval(i)
+		}
+		return slice
+	}
+
+	// Collect the overall counts and pad the intervals to include empty intervals
+	// which are not returned by the db
+	aggs.Aggregates = models.Aggregates{StartTime: startTime, EndTime: endTime}
+	var (
+		bigIntFromStringOK bool
+		totalVolume        = big.NewInt(0)
+		intervalVolume     = big.NewInt(0)
+	)
+
+	// Add each interval, but first pad up to that interval's index
+	aggs.Intervals = make([]models.Aggregates, 0, requestedIntervalCount)
+	for _, interval := range intervals {
+		// Pad up to this interval's position
+		aggs.Intervals = padTo(aggs.Intervals, interval.IntervalID)
+
+		// Format this interval
+		interval.StartTime, interval.EndTime = timesForInterval(interval.IntervalID)
+
+		// Parse volume into a big.Int
+		_, bigIntFromStringOK = intervalVolume.SetString(string(interval.TransactionVolume), 10)
+		if !bigIntFromStringOK {
+			return ErrFailedToParseStringAsBigInt
+		}
+
+		// Add to the overall aggregates counts
+		totalVolume.Add(totalVolume, intervalVolume)
+		aggs.Aggregates.TransactionCount += interval.TransactionCount
+		aggs.Aggregates.OutputCount += interval.OutputCount
+		aggs.Aggregates.AddressCount += interval.AddressCount
+		aggs.Aggregates.AssetCount += interval.AssetCount
+
+		// Add to the list of intervals
+		aggs.Intervals = append(aggs.Intervals, interval)
+	}
+	// Add total aggregated token amounts
+	aggs.Aggregates.TransactionVolume = models.TokenAmount(totalVolume.String())
+
+	// Add any missing trailing intervals
+	aggs.Intervals = padTo(aggs.Intervals, requestedIntervalCount)
+
+	aggs.StartTime = startTime
+	aggs.EndTime = endTime
+	ac.aggregateTransactionsMap[chainid][rangeKeyType] = aggs.Aggregates.TransactionCount
+	return nil
+}
+
+func (ac *aggregatesCache) GetAggregatesFeesAndUpdate(chains map[string]cfg.Chain, conns *utils.Connections, chainid string, startTime time.Time, endTime time.Time, rangeKeyType string) error {
+	chainIds := []string{chainid}
+	// Validate params and set defaults if necessary
+	if startTime.IsZero() {
+		var err error
+		startTime, err = getFirstTransactionTime(conns, chainIds)
+		if err != nil {
+			return err
+		}
+	}
+
+	intervals := models.TxfeeAggregatesList{}
+	urlv := url.Values{}
+	intervalSize, err := params.GetQueryInterval(urlv, params.KeyIntervalSize)
+
+	// Ensure the interval count requested isn't too large
+	intervalSeconds := int64(intervalSize.Seconds())
+	requestedIntervalCount := 0
+	if intervalSeconds != 0 {
+		requestedIntervalCount = int(math.Ceil(endTime.Sub(startTime).Seconds() / intervalSize.Seconds()))
+		if requestedIntervalCount > MaxAggregateIntervalCount {
+			return ErrAggregateIntervalCountTooLarge
+		}
+		if requestedIntervalCount < 1 {
+			requestedIntervalCount = 1
+		}
+	}
+
+	// Split chains
+	var avmChains, cvmChains []string
+	if len(chainIds) == 0 {
+		for id, chain := range chains {
+			switch chain.VMType {
+			case models.CVMName:
+				cvmChains = append(cvmChains, id)
+			default:
+				avmChains = append(avmChains, id)
+			}
+		}
+	} else {
+		for _, id := range chainIds {
+			chain, exist := chains[id]
+			if exist {
+				switch chain.VMType {
+				case models.CVMName:
+					cvmChains = append(cvmChains, id)
+				default:
+					avmChains = append(avmChains, id)
+				}
+			}
+		}
+	}
+
+	// Build the query and load the base data
+	dbRunner, err := conns.DB().NewSession("get_txfee_aggregates_histogram", cfg.RequestTimeout)
+	if err != nil {
+		return err
+	}
+
+	var builder *dbr.SelectStmt
+
+	if len(avmChains) > 0 {
+		columns := []string{
+			"CAST(COALESCE(SUM(avm_transactions.txfee), 0) AS UNSIGNED) AS txfee",
+		}
+
+		if requestedIntervalCount > 0 {
+			columns = append(columns, fmt.Sprintf(
+				"FLOOR((UNIX_TIMESTAMP(avm_transactions.created_at)-%d) / %d) AS interval_id",
+				startTime.Unix(),
+				intervalSeconds))
+		}
+
+		builder = dbRunner.
+			Select(columns...).
+			From("avm_transactions").
+			Where("avm_transactions.created_at >= ?", startTime).
+			Where("avm_transactions.created_at < ?", endTime)
+
+		if requestedIntervalCount > 0 {
+			builder.
+				GroupBy("interval_id").
+				OrderAsc("interval_id").
+				Limit(uint64(requestedIntervalCount))
+		}
+
+		if len(chainIds) != 0 {
+			builder.Where("avm_transactions.chain_id IN ?", chainIds)
+		}
+
+		_, err = builder.Load(&intervals)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(cvmChains) > 0 {
+		columns := []string{
+			"CAST(COALESCE(SUM((cvm_transactions_txdata.gas_price / 1000000000) * cvm_transactions_txdata.gas_used), 0) AS UNSIGNED) AS txfee",
+		}
+
+		if requestedIntervalCount > 0 {
+			columns = append(columns, fmt.Sprintf(
+				"FLOOR((UNIX_TIMESTAMP(cvm_transactions_txdata.created_at)-%d) / %d) AS interval_id",
+				startTime.Unix(),
+				intervalSeconds))
+		}
+
+		builder = dbRunner.
+			Select(columns...).
+			From("cvm_transactions_txdata").
+			Where("cvm_transactions_txdata.created_at >= ?", startTime).
+			Where("cvm_transactions_txdata.created_at < ?", endTime)
+
+		if requestedIntervalCount > 0 {
+			builder.
+				GroupBy("interval_id").
+				OrderAsc("interval_id").
+				Limit(uint64(requestedIntervalCount))
+		}
+
+		if len(chainIds) != 0 {
+			builder.
+				Join("cvm_blocks", "cvm_blocks.block = cvm_transactions_txdata.block").
+				Where("cvm_blocks.chain_id IN ?", cvmChains)
+		}
+
+		cvmIntervals := models.TxfeeAggregatesList{}
+
+		_, err = builder.Load(&cvmIntervals)
+		if err != nil {
+			return err
+		}
+
+		if len(intervals) == 0 {
+			intervals = cvmIntervals
+		} else {
+			models.MergeAggregates(intervals.MergeList(), cvmIntervals.MergeList())
+		}
+	}
+
+	// If no intervals were requested then the total aggregate is equal to the
+	// first (and only) interval, and we're done
+	if requestedIntervalCount == 0 {
+		// This check should never fail if the SQL query is correct, but added for
+		// robustness to prevent panics if the invariant does not hold.
+		if len(intervals) > 0 {
+			intervals[0].StartTime = startTime
+			intervals[0].EndTime = endTime
+			aggs := &models.TxfeeAggregatesHistogram{
+				TxfeeAggregates: intervals[0],
+				StartTime:       startTime,
+				EndTime:         endTime,
+			}
+			ac.aggregateFeesMap[chainid][rangeKeyType] = aggs.TxfeeAggregates.Txfee
+			return nil
+		}
+		aggs := &models.TxfeeAggregatesHistogram{
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+		ac.aggregateFeesMap[chainid][rangeKeyType] = aggs.TxfeeAggregates.Txfee
+		return nil
+	}
+
+	// We need to return multiple intervals so build them now.
+	// Intervals without any data will not return anything so we pad our results
+	// with empty aggregates.
+	//
+	// We also add the start and end times of each interval to that interval
+	aggs := &models.TxfeeAggregatesHistogram{IntervalSize: intervalSize}
+
+	var startTS int64
+	timesForInterval := func(intervalIdx int) (time.Time, time.Time) {
+		startTS = startTime.Unix() + (int64(intervalIdx) * intervalSeconds)
+		return time.Unix(startTS, 0).UTC(),
+			time.Unix(startTS+intervalSeconds-1, 0).UTC()
+	}
+
+	padTo := func(slice []models.TxfeeAggregates, to int) []models.TxfeeAggregates {
+		for i := len(slice); i < to; i = len(slice) {
+			slice = append(slice, models.TxfeeAggregates{IntervalID: i})
+			slice[i].StartTime, slice[i].EndTime = timesForInterval(i)
+		}
+		return slice
+	}
+
+	// Collect the overall counts and pad the intervals to include empty intervals
+	// which are not returned by the db
+	aggs.TxfeeAggregates = models.TxfeeAggregates{StartTime: startTime, EndTime: endTime}
+	var totalVolume uint64 = 0
+
+	// Add each interval, but first pad up to that interval's index
+	aggs.Intervals = make([]models.TxfeeAggregates, 0, requestedIntervalCount)
+	for _, interval := range intervals {
+		// Pad up to this interval's position
+		aggs.Intervals = padTo(aggs.Intervals, interval.IntervalID)
+
+		// Format this interval
+		interval.StartTime, interval.EndTime = timesForInterval(interval.IntervalID)
+
+		// Add to the overall aggregates counts
+		totalVolume += interval.Txfee
+
+		// Add to the list of intervals
+		aggs.Intervals = append(aggs.Intervals, interval)
+	}
+	// Add total aggregated token amounts
+	aggs.TxfeeAggregates.Txfee = totalVolume
+
+	// Add any missing trailing intervals
+	aggs.Intervals = padTo(aggs.Intervals, requestedIntervalCount)
+
+	aggs.StartTime = startTime
+	aggs.EndTime = endTime
+
+	ac.aggregateFeesMap[chainid][rangeKeyType] = aggs.TxfeeAggregates.Txfee
+	return nil
+}
+
+func getFirstTransactionTime(conns *utils.Connections, chainIDs []string) (time.Time, error) {
+	dbRunner, err := conns.DB().NewSession("get_first_transaction_time", cfg.RequestTimeout)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	var ts float64
+	builder := dbRunner.
+		Select("COALESCE(UNIX_TIMESTAMP(MIN(created_at)), 0)").
+		From("avm_transactions")
+
+	if len(chainIDs) > 0 {
+		builder.Where("avm_transactions.chain_id IN ?", chainIDs)
+	}
+
+	err = builder.LoadOne(&ts)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(int64(math.Floor(ts)), 0).UTC(), nil
+}

--- a/caching/cache.go
+++ b/caching/cache.go
@@ -1,7 +1,7 @@
 // (c) 2021, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package utils
+package caching
 
 import (
 	"context"
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/chain4travel/magellan/utils"
 )
 
 const (
@@ -48,11 +50,11 @@ type Cache interface {
 }
 
 type cacheContainer struct {
-	cache *LCache
+	cache *utils.LCache
 }
 
 func NewCache() Cache {
-	return &cacheContainer{cache: NewTTLMap()}
+	return &cacheContainer{cache: utils.NewTTLMap()}
 }
 
 func (c *cacheContainer) Get(_ context.Context, key string) ([]byte, error) {

--- a/caching/delay_cache.go
+++ b/caching/delay_cache.go
@@ -11,13 +11,14 @@
 // (c) 2021, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package utils
+package caching
 
 import (
 	"context"
 	"time"
 
 	"github.com/chain4travel/magellan/cfg"
+	"github.com/chain4travel/magellan/utils"
 )
 
 const (
@@ -33,12 +34,12 @@ type CacheJob struct {
 
 type DelayCache struct {
 	Cache  Cacher
-	Worker Worker
+	Worker utils.Worker
 }
 
 func NewDelayCache(cache Cacher) *DelayCache {
 	c := &DelayCache{Cache: cache}
-	c.Worker = NewWorker(WorkerQueueSize, WorkerThreadCount, c.Processor)
+	c.Worker = utils.NewWorker(WorkerQueueSize, WorkerThreadCount, c.Processor)
 	return c
 }
 

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -23,9 +23,6 @@ import (
 
 const appName = "magellan"
 
-var aggregateTransactionsMap = make(map[string]map[string]uint64)
-var aggregateFeesMap = make(map[string]map[string]uint64)
-
 var (
 	ErrChainsConfigMustBeStringMap = errors.New("Chain config must a string map")
 	ErrChainsConfigIDEmpty         = errors.New("Chain config ID is empty")
@@ -66,16 +63,17 @@ type AggregatesFeesMain struct {
 }
 
 type Config struct {
-	NetworkID         uint32 `json:"networkID"`
-	Chains            `json:"chains"`
-	Services          `json:"services"`
-	MetricsListenAddr string `json:"metricsListenAddr"`
-	AdminListenAddr   string `json:"adminListenAddr"`
-	Features          map[string]struct{}
-	CchainID          string `json:"cchainId"`
-	CaminoNode        string `json:"caminoNode"`
-	NodeInstance      string `json:"nodeInstance"`
-	AP5Activation     uint64
+	NetworkID           uint32 `json:"networkID"`
+	Chains              `json:"chains"`
+	Services            `json:"services"`
+	MetricsListenAddr   string `json:"metricsListenAddr"`
+	AdminListenAddr     string `json:"adminListenAddr"`
+	Features            map[string]struct{}
+	CchainID            string `json:"cchainId"`
+	CaminoNode          string `json:"caminoNode"`
+	NodeInstance        string `json:"nodeInstance"`
+	CacheUpdateInterval uint64 `json:"cacheUpdateInterval"`
+	AP5Activation       uint64
 }
 
 type Chain struct {
@@ -165,17 +163,10 @@ func NewFromFile(filePath string) (*Config, error) {
 				RODSN:  dbrodsn,
 			},
 		},
-		CchainID:      v.GetString(keysStreamProducerCchainID),
-		CaminoNode:    v.GetString(keysStreamProducerCaminoNode),
-		NodeInstance:  v.GetString(keysStreamProducerNodeInstance),
-		AP5Activation: uint64(ap5Activation),
+		CchainID:            v.GetString(keysStreamProducerCchainID),
+		CaminoNode:          v.GetString(keysStreamProducerCaminoNode),
+		NodeInstance:        v.GetString(keysStreamProducerNodeInstance),
+		CacheUpdateInterval: uint64(v.GetInt(keysCacheUpdateInterval)),
+		AP5Activation:       uint64(ap5Activation),
 	}, nil
-}
-
-func GetAggregateTransactionsMap() map[string]map[string]uint64 {
-	return aggregateTransactionsMap
-}
-
-func GetAggregateFeesMap() map[string]map[string]uint64 {
-	return aggregateFeesMap
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -23,6 +23,9 @@ import (
 
 const appName = "magellan"
 
+var aggregateTransactionsMap = make(map[string]uint64)
+var aggregateFeesMap = make(map[string]uint64)
+
 var (
 	ErrChainsConfigMustBeStringMap = errors.New("Chain config must a string map")
 	ErrChainsConfigIDEmpty         = errors.New("Chain config ID is empty")
@@ -32,6 +35,22 @@ var (
 	ErrChainsConfigVMNotString     = errors.New("Chain config vm type is not a string")
 )
 
+type Aggregates struct {
+	AggregateMerge    uint64 `json:"AggregateMerge"`
+	StartTime         string `json:"startTime"`
+	EndTime           string `json:"endTime"`
+	TransactionVolume uint64 `json:"transactionVolume"`
+	TransactionCount  uint64 `json:"transactionCount"`
+	AddressCount      uint64 `json:"addressCount"`
+	OutputCount       uint64 `json:"outputCount"`
+	AssetCount        uint64 `json:"assetCount"`
+}
+
+type AggregatesMain struct {
+	Aggregates Aggregates `json:"aggregates,omitempty"`
+	StartTime  string     `json:"startTime"`
+	EndTime    string     `json:"endTime"`
+}
 type Config struct {
 	NetworkID         uint32 `json:"networkID"`
 	Chains            `json:"chains"`
@@ -137,4 +156,12 @@ func NewFromFile(filePath string) (*Config, error) {
 		NodeInstance:  v.GetString(keysStreamProducerNodeInstance),
 		AP5Activation: uint64(ap5Activation),
 	}, nil
+}
+
+func GetAggregateTransactionsMap() map[string]uint64 {
+	return aggregateTransactionsMap
+}
+
+func GetAggregateFeesMap() map[string]uint64 {
+	return aggregateFeesMap
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -23,8 +23,8 @@ import (
 
 const appName = "magellan"
 
-var aggregateTransactionsMap = make(map[string]uint64)
-var aggregateFeesMap = make(map[string]uint64)
+var aggregateTransactionsMap = make(map[string]map[string]uint64)
+var aggregateFeesMap = make(map[string]map[string]uint64)
 
 var (
 	ErrChainsConfigMustBeStringMap = errors.New("Chain config must a string map")
@@ -158,10 +158,10 @@ func NewFromFile(filePath string) (*Config, error) {
 	}, nil
 }
 
-func GetAggregateTransactionsMap() map[string]uint64 {
+func GetAggregateTransactionsMap() map[string]map[string]uint64 {
 	return aggregateTransactionsMap
 }
 
-func GetAggregateFeesMap() map[string]uint64 {
+func GetAggregateFeesMap() map[string]map[string]uint64 {
 	return aggregateFeesMap
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -51,6 +51,20 @@ type AggregatesMain struct {
 	StartTime  string     `json:"startTime"`
 	EndTime    string     `json:"endTime"`
 }
+
+type AggregatesFees struct {
+	AggregateMerge uint64 `json:"AggregateMerge"`
+	StartTime      string `json:"startTime"`
+	EndTime        string `json:"endTime"`
+	Txfee          uint64 `json:"txfee"`
+}
+
+type AggregatesFeesMain struct {
+	Aggregates AggregatesFees `json:"aggregates,omitempty"`
+	StartTime  string         `json:"startTime"`
+	EndTime    string         `json:"endTime"`
+}
+
 type Config struct {
 	NetworkID         uint32 `json:"networkID"`
 	Chains            `json:"chains"`

--- a/cfg/commonu.go
+++ b/cfg/commonu.go
@@ -11,13 +11,14 @@ import (
 func GetDatepartBasedOnDateParams(pStartTime time.Time, pEndTime time.Time) string {
 	differenceInDays := int64(pEndTime.Sub(pStartTime).Hours() / 24)
 
-	if differenceInDays <= 1 {
+	switch {
+	case differenceInDays <= 1:
 		return "day"
-	} else if differenceInDays > 1 && differenceInDays <= 7 {
+	case differenceInDays > 1 && differenceInDays <= 7:
 		return "week"
-	} else if differenceInDays > 7 { //we leave that boundary open
+	case differenceInDays > 7:
 		return "month"
+	default:
+		return ""
 	}
-
-	return ""
 }

--- a/cfg/commonu.go
+++ b/cfg/commonu.go
@@ -5,14 +5,11 @@
 package cfg
 
 import (
-	"fmt"
 	"time"
 )
 
 func GetDatepartBasedOnDateParams(pStartTime time.Time, pEndTime time.Time) string {
 	differenceInDays := int64(pEndTime.Sub(pStartTime).Hours() / 24)
-	fmt.Print("diff in days:")
-	fmt.Println(differenceInDays)
 
 	if differenceInDays <= 1 {
 		return "day"

--- a/cfg/commonu.go
+++ b/cfg/commonu.go
@@ -18,7 +18,7 @@ func GetDatepartBasedOnDateParams(pStartTime time.Time, pEndTime time.Time) stri
 		return "day"
 	} else if differenceInDays > 1 && differenceInDays <= 7 {
 		return "week"
-	} else if differenceInDays > 7 && differenceInDays <= 31 {
+	} else if differenceInDays > 7 { //we leave that boundary open
 		return "month"
 	}
 

--- a/cfg/commonu.go
+++ b/cfg/commonu.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file contains helper functions
+
+package cfg
+
+import (
+	"fmt"
+	"time"
+)
+
+func GetDatepartBasedOnDateParams(pStartTime time.Time, pEndTime time.Time) string {
+	differenceInDays := int64(pEndTime.Sub(pStartTime).Hours() / 24)
+	fmt.Print("diff in days:")
+	fmt.Println(differenceInDays)
+
+	if differenceInDays <= 1 {
+		return "day"
+	} else if differenceInDays > 1 && differenceInDays <= 7 {
+		return "week"
+	} else if differenceInDays > 7 && differenceInDays <= 31 {
+		return "month"
+	}
+
+	return ""
+}

--- a/cfg/defaults.go
+++ b/cfg/defaults.go
@@ -15,6 +15,7 @@ package cfg
 
 const defaultJSON = `{
   "networkID": 1001,
+  "cacheUpdateInterval": "5",
   "logDirectory": "/tmp/magellan/logs",
   "listenAddr": ":8080",
   "chains": {},

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -37,4 +37,6 @@ const (
 	keysStreamProducerNodeInstance = "nodeInstance"
 
 	keysStreamProducerCchainID = "cchainID"
+
+	keysCacheUpdateInterval = "cacheUpdateInterval"
 )

--- a/cmds/magelland/magelland.go
+++ b/cmds/magelland/magelland.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -159,6 +160,11 @@ func execute() error {
 						}
 					}()
 				}
+				// init cache scheduler only when magellan starts as an api service
+				if strings.Compare(cmd.Use, apiCmdUse) == 0 {
+					go initCacheScheduler(config)
+
+				}
 			},
 		}
 	)
@@ -177,8 +183,6 @@ func execute() error {
 		createAPICmds(serviceControl, config, &runErr),
 		createEnvCmds(config, &runErr))
 
-	// init cache scheduler
-	go initCacheScheduler(config)
 	// Execute the command and return the runErr to the caller
 	if err := cmd.Execute(); err != nil {
 		return err

--- a/cmds/magelland/magelland.go
+++ b/cmds/magelland/magelland.go
@@ -426,7 +426,6 @@ func migrateMysql(mysqlDSN, migrationsPath string) error {
 
 //initialize scheduler-timer for cache
 func initCacheScheduler(config *cfg.Config) {
-	//cfg.Config.Chains
 	//we give a threshold of 10 seconds in order for the api server to fireup (since the caching mechanism is running as a separate thread)
 	time.Sleep(10 * time.Second)
 	toDate := time.Now()
@@ -449,17 +448,16 @@ func initCacheScheduler(config *cfg.Config) {
 
 		//update cache for all chains
 		for id := range config.Chains {
-			fmt.Println(id)
-			//get previous day aggregate number
-			fmt.Printf("Transaction Count 1 Day:" + getAggregatesAndUpdate(id, yesterdayDateTimeStr, toDateStr, "day") + "\n")
-			fmt.Printf("Fees Count 1 Day:" + getAggregatesFeesAndUpdate(id, yesterdayDateTimeStr, toDateStr, "day") + "\n")
-			//get previous week aggregate number
-			fmt.Printf("Transaction Count 1 Week:" + getAggregatesAndUpdate(id, prevWeekDateTimeStr, toDateStr, "week") + "\n")
-			fmt.Printf("Fees Count 1 Week:" + getAggregatesFeesAndUpdate(id, prevWeekDateTimeStr, toDateStr, "week") + "\n")
-			//get previous month aggregate number
-			fmt.Printf("Transaction Count 1 Month:" + getAggregatesAndUpdate(id, prevMonthDateTimeStr, toDateStr, "month") + "\n")
-			fmt.Printf("Fees Count 1 Month:" + getAggregatesFeesAndUpdate(id, prevMonthDateTimeStr, toDateStr, "month") + "\n")
-
+			//fmt.Println(id)
+			//previous day aggregate number
+			getAggregatesAndUpdate(id, yesterdayDateTimeStr, toDateStr, "day")
+			getAggregatesFeesAndUpdate(id, yesterdayDateTimeStr, toDateStr, "day")
+			//previous week aggregate number
+			getAggregatesAndUpdate(id, prevWeekDateTimeStr, toDateStr, "week")
+			getAggregatesFeesAndUpdate(id, prevWeekDateTimeStr, toDateStr, "week")
+			//previous month aggregate number
+			getAggregatesAndUpdate(id, prevMonthDateTimeStr, toDateStr, "month")
+			getAggregatesFeesAndUpdate(id, prevMonthDateTimeStr, toDateStr, "month")
 		}
 
 		MyTimer.Reset(3 * time.Second)

--- a/cmds/magelland/magelland.go
+++ b/cmds/magelland/magelland.go
@@ -177,7 +177,7 @@ func execute() error {
 		createAPICmds(serviceControl, config, &runErr),
 		createEnvCmds(config, &runErr))
 
-	//init cache scheduler
+	// init cache scheduler
 	go initCacheScheduler(config)
 	// Execute the command and return the runErr to the caller
 	if err := cmd.Execute(); err != nil {
@@ -421,37 +421,36 @@ func migrateMysql(mysqlDSN, migrationsPath string) error {
 	return nil
 }
 
-//initialize scheduler-timer for cache
+// initialize scheduler-timer for cache
 func initCacheScheduler(config *cfg.Config) {
-	//we give a threshold of 10 seconds in order for the api server to fireup (since the caching mechanism is running as a separate thread)
+	// we give a threshold of 10 seconds in order for the api server to fireup (since the caching mechanism is running as a separate thread)
 	time.Sleep(10 * time.Second)
 	initCacheStorage(config.Chains)
 
 	MyTimer := time.NewTimer(3 * time.Second)
 
-	for _ = range MyTimer.C {
+	for range MyTimer.C {
 		MyTimer.Stop()
 		toDate := time.Now()
 		yesterdayDateTime := time.Now().AddDate(0, 0, -1)
 		prevWeekDateTime := time.Now().AddDate(0, 0, -7)
 		prevMonthDateTime := time.Now().AddDate(0, -1, 0)
 
-		//convert to specific date format
+		// convert to specific date format
 		toDateStr := convertToMagellanDateFormat(toDate)
 		yesterdayDateTimeStr := convertToMagellanDateFormat(yesterdayDateTime)
 		prevWeekDateTimeStr := convertToMagellanDateFormat(prevWeekDateTime)
 		prevMonthDateTimeStr := convertToMagellanDateFormat(prevMonthDateTime)
 
-		//update cache for all chains
+		// update cache for all chains
 		for id := range config.Chains {
-			//fmt.Println(id)
-			//previous day aggregate number
+			// previous day aggregate number
 			getAggregatesAndUpdate(id, yesterdayDateTimeStr, toDateStr, "day")
 			getAggregatesFeesAndUpdate(id, yesterdayDateTimeStr, toDateStr, "day")
-			//previous week aggregate number
+			// previous week aggregate number
 			getAggregatesAndUpdate(id, prevWeekDateTimeStr, toDateStr, "week")
 			getAggregatesFeesAndUpdate(id, prevWeekDateTimeStr, toDateStr, "week")
-			//previous month aggregate number
+			// previous month aggregate number
 			getAggregatesAndUpdate(id, prevMonthDateTimeStr, toDateStr, "month")
 			getAggregatesFeesAndUpdate(id, prevMonthDateTimeStr, toDateStr, "month")
 		}
@@ -467,23 +466,23 @@ func initCacheStorage(pchains cfg.Chains) {
 		aggregateTransMap[id] = map[string]uint64{}
 		aggregateFeesMap[id] = map[string]uint64{}
 
-		//we initialize the value for all 3 chains
+		// we initialize the value for all 3 chains
 		aggregateTransMap[id]["day"] = 0
 		aggregateTransMap[id]["week"] = 0
 		aggregateTransMap[id]["month"] = 0
 
-		//we initialize the value for all 3 chains also here
+		// we initialize the value for all 3 chains also here
 		aggregateFeesMap[id]["day"] = 0
 		aggregateFeesMap[id]["week"] = 0
 		aggregateFeesMap[id]["month"] = 0
 	}
 }
 
-func getAggregatesAndUpdate(chainid string, startTime string, endTime string, rangeKeyType string) string {
+func getAggregatesAndUpdate(chainid string, startTime string, endTime string, rangeKeyType string) {
 	serverPort := 8080
 	requestURL := fmt.Sprintf("http://localhost:%d/v2/aggregates?cacheUpd=true&chainID="+chainid+"&startTime="+startTime+"&endTime="+endTime, serverPort)
 
-	res, err := http.Get(requestURL)
+	res, err := http.Get(requestURL) //nolint
 	if err != nil {
 		fmt.Printf("error making http request: %s\n", err)
 	}
@@ -494,20 +493,20 @@ func getAggregatesAndUpdate(chainid string, startTime string, endTime string, ra
 			fmt.Printf("client: could not read response body: %s\n", err)
 		}
 		var aggregatesMain cfg.AggregatesMain
-		aggregatesMainJson := resBody
-		json.Unmarshal([]byte(aggregatesMainJson), &aggregatesMain)
-		//based on the rangeKeyType we update the relevant part of our map - cache (we could imply that from the diff endTime - startTime but for simplicity we added this switch)
-		cfg.GetAggregateTransactionsMap()[chainid][rangeKeyType] = aggregatesMain.Aggregates.TransactionCount
-		return strconv.FormatUint(aggregatesMain.Aggregates.TransactionCount, 10)
+		aggregatesMainJSON := resBody
+		err = json.Unmarshal(aggregatesMainJSON, &aggregatesMain)
+		if err != nil {
+			// based on the rangeKeyType we update the relevant part of our map - cache (we could imply that from the diff endTime - startTime but for simplicity we added this switch)
+			cfg.GetAggregateTransactionsMap()[chainid][rangeKeyType] = aggregatesMain.Aggregates.TransactionCount
+		}
 	}
-	return ""
 }
 
-func getAggregatesFeesAndUpdate(chainid string, startTime string, endTime string, rangeKeyType string) string {
+func getAggregatesFeesAndUpdate(chainid string, startTime string, endTime string, rangeKeyType string) {
 	serverPort := 8080
 	requestURL := fmt.Sprintf("http://localhost:%d/v2/txfeeAggregates?cacheUpd=true&chainID="+chainid+"&startTime="+startTime+"&endTime="+endTime, serverPort)
 
-	res, err := http.Get(requestURL)
+	res, err := http.Get(requestURL) //nolint
 	if err != nil {
 		fmt.Printf("error making http request: %s\n", err)
 	}
@@ -518,17 +517,17 @@ func getAggregatesFeesAndUpdate(chainid string, startTime string, endTime string
 			fmt.Printf("client: could not read response body: %s\n", err)
 		}
 		var aggregatesFeesMain cfg.AggregatesFeesMain
-		aggregatesFeesMainJson := resBody
-		json.Unmarshal([]byte(aggregatesFeesMainJson), &aggregatesFeesMain)
-		//based on the rangeKeyType we update the relevant part of our map - cache (we could imply that from the diff endTime - startTime but for simplicity we added this switch)
-		cfg.GetAggregateFeesMap()[chainid][rangeKeyType] = aggregatesFeesMain.Aggregates.Txfee
-		return strconv.FormatUint(aggregatesFeesMain.Aggregates.Txfee, 10)
+		aggregatesFeesMainJSON := resBody
+		err = json.Unmarshal(aggregatesFeesMainJSON, &aggregatesFeesMain)
+		if err != nil {
+			// based on the rangeKeyType we update the relevant part of our map - cache (we could imply that from the diff endTime - startTime but for simplicity we added this switch)
+			cfg.GetAggregateFeesMap()[chainid][rangeKeyType] = aggregatesFeesMain.Aggregates.Txfee
+		}
 	}
-	return ""
 }
 
 func convertToMagellanDateFormat(pDateTime time.Time) string {
-	//we need to convert to format e.g 2022-07-01T10:21:16.808Z
+	// we need to convert to format e.g 2022-07-01T10:21:16.808Z
 	return strconv.Itoa(pDateTime.Year()) + "-" + lpadDatePart(int(pDateTime.Month())) + "-" + lpadDatePart(pDateTime.Day()) + "T" + lpadDatePart(pDateTime.Hour()) + ":" + lpadDatePart(pDateTime.Minute()) + ":" + lpadDatePart(pDateTime.Second()) + "." + "000Z"
 }
 

--- a/cmds/magelland/magelland.go
+++ b/cmds/magelland/magelland.go
@@ -70,9 +70,6 @@ const (
 )
 
 func main() {
-	//init cache key values
-	//initCacheStorage()
-
 	if err := execute(); err != nil {
 		log.Fatalln("Failed to run:", err.Error())
 	}
@@ -428,23 +425,22 @@ func migrateMysql(mysqlDSN, migrationsPath string) error {
 func initCacheScheduler(config *cfg.Config) {
 	//we give a threshold of 10 seconds in order for the api server to fireup (since the caching mechanism is running as a separate thread)
 	time.Sleep(10 * time.Second)
-	toDate := time.Now()
-	yesterdayDateTime := time.Now().AddDate(0, 0, -1)
-	prevWeekDateTime := time.Now().AddDate(0, 0, -7)
-	prevMonthDateTime := time.Now().AddDate(0, -1, 0)
-
-	//convert to specific date format
-	toDateStr := convertToMagellanDateFormat(toDate)
-	yesterdayDateTimeStr := convertToMagellanDateFormat(yesterdayDateTime)
-	prevWeekDateTimeStr := convertToMagellanDateFormat(prevWeekDateTime)
-	prevMonthDateTimeStr := convertToMagellanDateFormat(prevMonthDateTime)
-
 	initCacheStorage(config.Chains)
 
 	MyTimer := time.NewTimer(3 * time.Second)
 
 	for _ = range MyTimer.C {
 		MyTimer.Stop()
+		toDate := time.Now()
+		yesterdayDateTime := time.Now().AddDate(0, 0, -1)
+		prevWeekDateTime := time.Now().AddDate(0, 0, -7)
+		prevMonthDateTime := time.Now().AddDate(0, -1, 0)
+
+		//convert to specific date format
+		toDateStr := convertToMagellanDateFormat(toDate)
+		yesterdayDateTimeStr := convertToMagellanDateFormat(yesterdayDateTime)
+		prevWeekDateTimeStr := convertToMagellanDateFormat(prevWeekDateTime)
+		prevMonthDateTimeStr := convertToMagellanDateFormat(prevMonthDateTime)
 
 		//update cache for all chains
 		for id := range config.Chains {

--- a/cmds/magelland/magelland.go
+++ b/cmds/magelland/magelland.go
@@ -163,7 +163,6 @@ func execute() error {
 				// init cache scheduler only when magellan starts as an api service
 				if strings.Compare(cmd.Use, apiCmdUse) == 0 {
 					go initCacheScheduler(config)
-
 				}
 			},
 		}

--- a/db/dbmodel_test.go
+++ b/db/dbmodel_test.go
@@ -23,8 +23,10 @@ import (
 	"github.com/gocraft/dbr/v2"
 )
 
-const TestDB = "mysql"
-const TestDSN = "root:password@tcp(127.0.0.1:3306)/magellan_test?parseTime=true"
+const (
+	TestDB  = "mysql"
+	TestDSN = "root:password@tcp(127.0.0.1:3306)/magellan_test?parseTime=true"
+)
 
 func TestTransaction(t *testing.T) {
 	p := NewPersist()

--- a/docker/standalone/docker-compose.yml
+++ b/docker/standalone/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   camino:
     env_file:
       - standalone.env
-    image: "c4tplatform/camino-node:v0.2.0"
+    image: "c4tplatform/camino-node:v0.2.1-rc1"
     command: /bin/sh -cx "exec /camino-node/build/camino-node
       --config-file=/opt/config.json
       --network-id=$${NETWORKID}
@@ -19,14 +19,14 @@ services:
       - "9650:9650"
     volumes:
       - camino-data:/var/lib/camino
-      - ./../camino-node_config.json:/opt/config.json
-      - ./../camino-node_chain_config:/opt/camino-node
+      - ./../caminogo_config.json:/opt/config.json
+      - ./../caminogo_chain_config:/opt/camino-node
       - camino-ipcs:/tmp
     depends_on:
       - indexer
     restart: always
   indexer: &magellan-app
-    image: "c4tplatform/magellan:v0.1.0"
+    image: "c4tplatform/magellan:v0.2.5"
     command: ["stream", "indexer", "-c", "/opt/config.json"]
     networks:
       - services

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -383,9 +383,8 @@ func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams, 
 		cache := models.AggregatesList{}
 		var temp = models.Aggregates{}
 		//based on the date interval we are going to retrieve the relevant part from our cache
-		temp.TransactionCount = cfg.GetAggregateTransactionsMap()["month"]
-		//temp.StartTime = time.Now()
-		//temp.EndTime = time.Now()
+		var keyDatePartValue = cfg.GetDatepartBasedOnDateParams(params.ListParams.StartTime, params.ListParams.EndTime)
+		temp.TransactionCount = cfg.GetAggregateTransactionsMap()[keyDatePartValue]
 
 		cache = append(cache, temp)
 		cache[0].StartTime = params.ListParams.StartTime

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -164,11 +164,11 @@ func (r *Reader) Search(ctx context.Context, p *params.SearchParams, avaxAssetID
 }
 
 func (r *Reader) TxfeeAggregate(ctx context.Context, params *params.TxfeeAggregateParams) (*models.TxfeeAggregatesHistogram, error) {
-	//if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
+	// if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
 	if !params.ListParams.Values.Has("cacheUpd") {
 		cache := models.TxfeeAggregatesList{}
 		var temp = models.TxfeeAggregates{}
-		//based on the date interval we are going to retrieve the relevant part from our cache
+		// based on the date interval we are going to retrieve the relevant part from our cache
 		var keyDatePartValue = cfg.GetDatepartBasedOnDateParams(params.ListParams.StartTime, params.ListParams.EndTime)
 		temp.Txfee = cfg.GetAggregateFeesMap()[params.ChainIDs[0]][keyDatePartValue]
 
@@ -180,7 +180,6 @@ func (r *Reader) TxfeeAggregate(ctx context.Context, params *params.TxfeeAggrega
 			StartTime:       params.ListParams.StartTime,
 			EndTime:         params.ListParams.EndTime,
 		}, nil
-
 	}
 
 	// Validate params and set defaults if necessary
@@ -396,10 +395,10 @@ func (r *Reader) TxfeeAggregate(ctx context.Context, params *params.TxfeeAggrega
 
 func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams, conns *utils.Connections) (*models.AggregatesHistogram, error) {
 	if !params.ListParams.Values.Has("cacheUpd") {
-		//if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
+		// if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
 		cache := models.AggregatesList{}
 		var temp = models.Aggregates{}
-		//based on the date interval we are going to retrieve the relevant part from our cache
+		// based on the date interval we are going to retrieve the relevant part from our cache
 		var keyDatePartValue = cfg.GetDatepartBasedOnDateParams(params.ListParams.StartTime, params.ListParams.EndTime)
 		temp.TransactionCount = cfg.GetAggregateTransactionsMap()[params.ChainIDs[0]][keyDatePartValue]
 
@@ -411,7 +410,6 @@ func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams, 
 			StartTime:  params.ListParams.StartTime,
 			EndTime:    params.ListParams.EndTime,
 		}, nil
-
 	}
 	// Validate params and set defaults if necessary
 	if params.ListParams.StartTime.IsZero() {

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -395,6 +395,7 @@ func (r *Reader) TxfeeAggregate(ctx context.Context, params *params.TxfeeAggrega
 	return aggs, nil
 }
 
+//gocyclo:ignore
 func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams, conns *utils.Connections) (*models.AggregatesHistogram, error) {
 	var aggregateTransactionMap = cfg.GetAggregateTransactionsMap()
 	if !params.ListParams.Values.Has("cacheUpd") && len(aggregateTransactionMap) != 0 {

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -164,15 +164,11 @@ func (r *Reader) Search(ctx context.Context, p *params.SearchParams, avaxAssetID
 }
 
 func (r *Reader) TxfeeAggregate(ctx context.Context, params *params.TxfeeAggregateParams) (*models.TxfeeAggregatesHistogram, error) {
+	//if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
 	if !params.ListParams.Values.Has("cacheUpd") {
-
-		//if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
-		//if params.ListParams.Values["cacheUpd"][0] != "true" {
 		cache := models.TxfeeAggregatesList{}
 		var temp = models.TxfeeAggregates{}
 		//based on the date interval we are going to retrieve the relevant part from our cache
-
-		//############
 		var keyDatePartValue = cfg.GetDatepartBasedOnDateParams(params.ListParams.StartTime, params.ListParams.EndTime)
 		temp.Txfee = cfg.GetAggregateFeesMap()[params.ChainIDs[0]][keyDatePartValue]
 
@@ -400,14 +396,10 @@ func (r *Reader) TxfeeAggregate(ctx context.Context, params *params.TxfeeAggrega
 
 func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams, conns *utils.Connections) (*models.AggregatesHistogram, error) {
 	if !params.ListParams.Values.Has("cacheUpd") {
-
 		//if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
-		//if params.ListParams.Values["cacheUpd"][0] != "true" {
 		cache := models.AggregatesList{}
 		var temp = models.Aggregates{}
 		//based on the date interval we are going to retrieve the relevant part from our cache
-
-		//############
 		var keyDatePartValue = cfg.GetDatepartBasedOnDateParams(params.ListParams.StartTime, params.ListParams.EndTime)
 		temp.TransactionCount = cfg.GetAggregateTransactionsMap()[params.ChainIDs[0]][keyDatePartValue]
 

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -376,6 +376,27 @@ func (r *Reader) TxfeeAggregate(ctx context.Context, params *params.TxfeeAggrega
 }
 
 func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams, conns *utils.Connections) (*models.AggregatesHistogram, error) {
+	if !params.ListParams.Values.Has("cacheUpd") {
+
+		//if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
+		//if params.ListParams.Values["cacheUpd"][0] != "true" {
+		cache := models.AggregatesList{}
+		var temp = models.Aggregates{}
+		//based on the date interval we are going to retrieve the relevant part from our cache
+		temp.TransactionCount = cfg.GetAggregateTransactionsMap()["month"]
+		//temp.StartTime = time.Now()
+		//temp.EndTime = time.Now()
+
+		cache = append(cache, temp)
+		cache[0].StartTime = params.ListParams.StartTime
+		cache[0].EndTime = params.ListParams.EndTime
+		return &models.AggregatesHistogram{
+			Aggregates: cache[0],
+			StartTime:  params.ListParams.StartTime,
+			EndTime:    params.ListParams.EndTime,
+		}, nil
+
+	}
 	// Validate params and set defaults if necessary
 	if params.ListParams.StartTime.IsZero() {
 		var err error

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -383,8 +383,10 @@ func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams, 
 		cache := models.AggregatesList{}
 		var temp = models.Aggregates{}
 		//based on the date interval we are going to retrieve the relevant part from our cache
+
+		//############
 		var keyDatePartValue = cfg.GetDatepartBasedOnDateParams(params.ListParams.StartTime, params.ListParams.EndTime)
-		temp.TransactionCount = cfg.GetAggregateTransactionsMap()[keyDatePartValue]
+		temp.TransactionCount = cfg.GetAggregateTransactionsMap()[params.ChainIDs[0]][keyDatePartValue]
 
 		cache = append(cache, temp)
 		cache[0].StartTime = params.ListParams.StartTime

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -165,12 +165,14 @@ func (r *Reader) Search(ctx context.Context, p *params.SearchParams, avaxAssetID
 
 func (r *Reader) TxfeeAggregate(ctx context.Context, params *params.TxfeeAggregateParams) (*models.TxfeeAggregatesHistogram, error) {
 	// if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
-	if !params.ListParams.Values.Has("cacheUpd") {
+	var aggregateFeesMap = cfg.GetAggregateFeesMap()
+	if !params.ListParams.Values.Has("cacheUpd") && len(aggregateFeesMap) != 0 {
 		cache := models.TxfeeAggregatesList{}
 		var temp = models.TxfeeAggregates{}
+
 		// based on the date interval we are going to retrieve the relevant part from our cache
 		var keyDatePartValue = cfg.GetDatepartBasedOnDateParams(params.ListParams.StartTime, params.ListParams.EndTime)
-		temp.Txfee = cfg.GetAggregateFeesMap()[params.ChainIDs[0]][keyDatePartValue]
+		temp.Txfee = aggregateFeesMap[params.ChainIDs[0]][keyDatePartValue]
 
 		cache = append(cache, temp)
 		cache[0].StartTime = params.ListParams.StartTime
@@ -394,13 +396,14 @@ func (r *Reader) TxfeeAggregate(ctx context.Context, params *params.TxfeeAggrega
 }
 
 func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams, conns *utils.Connections) (*models.AggregatesHistogram, error) {
-	if !params.ListParams.Values.Has("cacheUpd") {
+	var aggregateTransactionMap = cfg.GetAggregateTransactionsMap()
+	if !params.ListParams.Values.Has("cacheUpd") && len(aggregateTransactionMap) != 0 {
 		// if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
 		cache := models.AggregatesList{}
 		var temp = models.Aggregates{}
 		// based on the date interval we are going to retrieve the relevant part from our cache
 		var keyDatePartValue = cfg.GetDatepartBasedOnDateParams(params.ListParams.StartTime, params.ListParams.EndTime)
-		temp.TransactionCount = cfg.GetAggregateTransactionsMap()[params.ChainIDs[0]][keyDatePartValue]
+		temp.TransactionCount = aggregateTransactionMap[params.ChainIDs[0]][keyDatePartValue]
 
 		cache = append(cache, temp)
 		cache[0].StartTime = params.ListParams.StartTime
@@ -411,6 +414,7 @@ func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams, 
 			EndTime:    params.ListParams.EndTime,
 		}, nil
 	}
+
 	// Validate params and set defaults if necessary
 	if params.ListParams.StartTime.IsZero() {
 		var err error

--- a/services/indexes/avax/reader_aggregate_processor.go
+++ b/services/indexes/avax/reader_aggregate_processor.go
@@ -451,7 +451,7 @@ func (r *Reader) aggregateProcessorAssetAggr(conns *utils.Connections) {
 			}
 			p.AssetID = &id
 			r.sc.Log.Info("aggregate %s %v-%v", id.String(), p.ListParams.StartTime.Format(time.RFC3339), p.ListParams.EndTime.Format(time.RFC3339))
-			aggr, err := r.Aggregate(ctx, p, conns)
+			aggr, err := r.Aggregate(r.sc.AggregatesCache, p)
 			if err != nil {
 				r.sc.Log.Warn("Aggregate %v", err)
 				return
@@ -525,8 +525,7 @@ func (r *Reader) aggregateProcessorAssetAggr(conns *utils.Connections) {
 	}
 }
 
-func (r *Reader) processAggregate(conns *utils.Connections, runTm time.Time, tag string, intervalSize string, deltaTime time.Duration) (*models.AggregatesHistogram, error) {
-	ctx := context.Background()
+func (r *Reader) processAggregate(runTm time.Time, tag string, intervalSize string, deltaTime time.Duration) (*models.AggregatesHistogram, error) {
 	p := &params.AggregateParams{}
 	urlv := url.Values{}
 	urlv.Add(params.KeyIntervalSize, intervalSize)
@@ -539,7 +538,7 @@ func (r *Reader) processAggregate(conns *utils.Connections, runTm time.Time, tag
 	p.ListParams.StartTime = p.ListParams.EndTime.Add(deltaTime)
 	p.ChainIDs = append(p.ChainIDs, r.sc.GenesisContainer.XChainID.String())
 	r.sc.Log.Info("aggregate %s interval %s %v->%v", tag, intervalSize, p.ListParams.StartTime.Format(time.RFC3339), p.ListParams.EndTime.Format(time.RFC3339))
-	return r.Aggregate(ctx, p, conns)
+	return r.Aggregate(r.sc.AggregatesCache, p)
 }
 
 func (r *Reader) aggregateProcessor1m(conns *utils.Connections) {
@@ -552,7 +551,7 @@ func (r *Reader) aggregateProcessor1m(conns *utils.Connections) {
 	time1m := time.Now().Truncate(time.Minute)
 
 	runAgg := func(runTm time.Time) {
-		agg, err := r.processAggregate(conns, runTm, "1m", "1s", -time.Minute)
+		agg, err := r.processAggregate(runTm, "1m", "1s", -time.Minute)
 		if err != nil {
 			r.sc.Log.Warn("Aggregate %v", err)
 			return
@@ -586,7 +585,7 @@ func (r *Reader) aggregateProcessor1h(conns *utils.Connections) {
 	time1h := time.Now().Truncate(time.Minute).Truncate(5 * time.Minute)
 
 	runAgg := func(runtm time.Time) {
-		agg, err := r.processAggregate(conns, runtm, "1h", "5m", -time.Hour)
+		agg, err := r.processAggregate(runtm, "1h", "5m", -time.Hour)
 		if err != nil {
 			r.sc.Log.Warn("Aggregate %v", err)
 			return
@@ -620,7 +619,7 @@ func (r *Reader) aggregateProcessor24h(conns *utils.Connections) {
 	time24h := time.Now().Truncate(time.Minute).Truncate(15 * time.Minute)
 
 	runAgg := func(runTm time.Time) {
-		agg, err := r.processAggregate(conns, runTm, "24h", "hour", -(24 * time.Hour))
+		agg, err := r.processAggregate(runTm, "24h", "hour", -(24 * time.Hour))
 		if err != nil {
 			r.sc.Log.Warn("Aggregate %v", err)
 			return
@@ -654,7 +653,7 @@ func (r *Reader) aggregateProcessor7d(conns *utils.Connections) {
 	time7d := time.Now().Truncate(time.Minute).Truncate(30 * time.Minute)
 
 	runAgg := func(runTm time.Time) {
-		agg, err := r.processAggregate(conns, runTm, "7d", "day", -(7 * 24 * time.Hour))
+		agg, err := r.processAggregate(runTm, "7d", "day", -(7 * 24 * time.Hour))
 		if err != nil {
 			r.sc.Log.Warn("Aggregate %v", err)
 			return
@@ -688,7 +687,7 @@ func (r *Reader) aggregateProcessor30d(conns *utils.Connections) {
 	time30d := time.Now().Truncate(time.Minute).Truncate(30 * time.Minute)
 
 	runAgg := func(runTm time.Time) {
-		agg, err := r.processAggregate(conns, runTm, "30d", "day", -(30 * 24 * time.Hour))
+		agg, err := r.processAggregate(runTm, "30d", "day", -(30 * 24 * time.Hour))
 		if err != nil {
 			r.sc.Log.Warn("Aggregate %v", err)
 			return

--- a/services/indexes/avax/reader_test.go
+++ b/services/indexes/avax/reader_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/chain4travel/caminogo/utils/logging"
+	"github.com/chain4travel/magellan/caching"
 	"github.com/chain4travel/magellan/cfg"
 	"github.com/chain4travel/magellan/db"
 	"github.com/chain4travel/magellan/models"
@@ -133,7 +134,7 @@ func TestCollectInsAndOuts(t *testing.T) {
 	}
 }
 
-func TestAggregateTxfee(t *testing.T) {
+func TestAggregates(t *testing.T) {
 	reader, closeFn := newTestIndex(t)
 	defer closeFn()
 
@@ -141,48 +142,228 @@ func TestAggregateTxfee(t *testing.T) {
 
 	persist := db.NewPersist()
 
-	sess, _ := reader.conns.DB().NewSession("test_aggregate_tx_fee", cfg.RequestTimeout)
-	_, _ = sess.DeleteFrom("avm_transactions").ExecContext(ctx)
+	sessTx, _ := reader.conns.DB().NewSession("test_aggregate_tx_fee", cfg.RequestTimeout)
+	_, _ = sessTx.DeleteFrom("avm_transactions").ExecContext(ctx)
 
-	tnow := time.Now().UTC().Truncate(1 * time.Second).Add(-1 * time.Hour)
+	sessOuts, _ := reader.conns.DB().NewSession("test_aggregate_tx", cfg.RequestTimeout)
+	_, _ = sessOuts.DeleteFrom("avm_outputs").ExecContext(ctx)
 
+	timeNow := time.Now().UTC().Truncate(1 * time.Second)
+	yesterdayDateTime := time.Now().UTC().AddDate(0, 0, -1)
+	prevWeekDateTime := time.Now().UTC().AddDate(0, 0, -7)
+	prevMonthDateTime := time.Now().UTC().AddDate(0, -1, 0)
+
+	// Add transaction and output to test last days' aggregates
 	transaction := &db.Transactions{
 		ID:        "id1",
 		ChainID:   "cid",
 		Type:      "type",
 		Txfee:     10,
-		CreatedAt: tnow,
+		CreatedAt: timeNow.Add(-1 * time.Hour),
 	}
-	_ = persist.InsertTransactions(ctx, sess, transaction, false)
+	_ = persist.InsertTransactions(ctx, sessTx, transaction, false)
+	output := &db.Outputs{
+		ID:            "id1",
+		TransactionID: "id1",
+		ChainID:       "cid",
+		CreatedAt:     timeNow.Add(-1 * time.Hour),
+	}
+	_ = persist.InsertOutputs(ctx, sessOuts, output, false)
 
+	err := reader.sc.AggregatesCache.GetAggregatesFeesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		yesterdayDateTime,
+		timeNow.Add(1*time.Hour),
+		"day")
+	if err != nil {
+		t.Error("error", err)
+	}
+	err = reader.sc.AggregatesCache.GetAggregatesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		yesterdayDateTime,
+		timeNow.Add(1*time.Hour),
+		"day")
+	if err != nil {
+		t.Error("error", err)
+	}
+
+	// Add transaction and output to test last week's aggregates
 	transaction = &db.Transactions{
 		ID:        "id2",
 		ChainID:   "cid",
 		Type:      "type",
 		Txfee:     15,
-		CreatedAt: tnow.Add(-1 * time.Hour),
+		CreatedAt: timeNow.Add(-48 * time.Hour),
 	}
-	_ = persist.InsertTransactions(ctx, sess, transaction, false)
+	_ = persist.InsertTransactions(ctx, sessTx, transaction, false)
+	output = &db.Outputs{
+		ID:            "id2",
+		TransactionID: "id2",
+		ChainID:       "cid",
+		CreatedAt:     timeNow.Add(-48 * time.Hour),
+	}
+	_ = persist.InsertOutputs(ctx, sessOuts, output, false)
 
-	starttime := tnow.Add(-2 * time.Hour)
-	endtime := tnow.Add(1 * time.Second)
-	p := params.TxfeeAggregateParams{ListParams: params.ListParams{StartTime: starttime, EndTime: endtime}}
-	agg, err := reader.TxfeeAggregate(ctx, &p)
+	err = reader.sc.AggregatesCache.GetAggregatesFeesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		prevWeekDateTime,
+		timeNow.Add(1*time.Hour),
+		"week")
 	if err != nil {
 		t.Error("error", err)
 	}
-	if agg.TxfeeAggregates.Txfee != 25 {
-		t.Error("aggregate tx invalid expected ", agg.TxfeeAggregates.Txfee)
+	err = reader.sc.AggregatesCache.GetAggregatesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		prevWeekDateTime,
+		timeNow.Add(1*time.Hour),
+		"week")
+	if err != nil {
+		t.Error("error", err)
 	}
-	if agg.StartTime != starttime || agg.EndTime != endtime {
+
+	// Add transaction and output to test last month's aggregates
+	transaction = &db.Transactions{
+		ID:        "id3",
+		ChainID:   "cid",
+		Type:      "type",
+		Txfee:     20,
+		CreatedAt: timeNow.Add(-200 * time.Hour),
+	}
+	_ = persist.InsertTransactions(ctx, sessTx, transaction, false)
+	output = &db.Outputs{
+		ID:            "id3",
+		TransactionID: "id3",
+		ChainID:       "cid",
+		CreatedAt:     timeNow.Add(-200 * time.Hour),
+	}
+	_ = persist.InsertOutputs(ctx, sessOuts, output, false)
+
+	err = reader.sc.AggregatesCache.GetAggregatesFeesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		prevMonthDateTime,
+		timeNow.Add(1*time.Hour),
+		"month")
+	if err != nil {
+		t.Error("error", err)
+	}
+	err = reader.sc.AggregatesCache.GetAggregatesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		prevMonthDateTime,
+		timeNow.Add(1*time.Hour),
+		"month")
+	if err != nil {
+		t.Error("error", err)
+	}
+
+	// Test last month's aggregates
+	startTime := timeNow.Add(-250 * time.Hour)
+	endTime := timeNow.Add(1 * time.Hour)
+
+	feeAggregateParams := params.TxfeeAggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	aggFees, err := reader.TxfeeAggregate(reader.sc.AggregatesCache, &feeAggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if aggFees.TxfeeAggregates.Txfee != 45 {
+		t.Errorf("Expected %d tx aggregate fees", 45)
+	}
+	if aggFees.StartTime != startTime || aggFees.EndTime != endTime {
+		t.Error("aggregate tx invalid")
+	}
+	aggregateParams := params.AggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	agg, err := reader.Aggregate(reader.sc.AggregatesCache, &aggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if agg.Aggregates.TransactionCount != 3 {
+		t.Errorf("Expected %d txs", 3)
+	}
+	if agg.StartTime != startTime || agg.EndTime != endTime {
 		t.Error("aggregate tx invalid")
 	}
 
-	p = params.TxfeeAggregateParams{ListParams: params.ListParams{StartTime: tnow.Add(-50 * time.Minute), EndTime: tnow.Add(1 * time.Second)}}
-	agg, _ = reader.TxfeeAggregate(ctx, &p)
+	// Test last week's aggregate fees
+	startTime = timeNow.Add(-50 * time.Hour)
+	endTime = timeNow.Add(1 * time.Hour)
 
-	if agg.TxfeeAggregates.Txfee != 10 {
-		t.Error("aggregate tx invalid expected ", agg.TxfeeAggregates.Txfee)
+	feeAggregateParams = params.TxfeeAggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	aggFees, err = reader.TxfeeAggregate(reader.sc.AggregatesCache, &feeAggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if aggFees.TxfeeAggregates.Txfee != 25 {
+		t.Errorf("Expected %d tx aggregate fees", 25)
+	}
+	if aggFees.StartTime != startTime || aggFees.EndTime != endTime {
+		t.Error("aggregate tx invalid")
+	}
+	aggregateParams = params.AggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	agg, err = reader.Aggregate(reader.sc.AggregatesCache, &aggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if agg.Aggregates.TransactionCount != 2 {
+		t.Errorf("Expected %d txs", 2)
+	}
+	if agg.StartTime != startTime || agg.EndTime != endTime {
+		t.Error("aggregate tx invalid")
+	}
+
+	// Test last days' aggregate fees
+	startTime = timeNow.Add(-5 * time.Hour)
+	endTime = timeNow.Add(1 * time.Hour)
+
+	feeAggregateParams = params.TxfeeAggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	aggFees, err = reader.TxfeeAggregate(reader.sc.AggregatesCache, &feeAggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if aggFees.TxfeeAggregates.Txfee != 10 {
+		t.Errorf("Expected %d tx aggregate fees", 10)
+	}
+	if aggFees.StartTime != startTime || aggFees.EndTime != endTime {
+		t.Error("aggregate tx invalid")
+	}
+	aggregateParams = params.AggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	agg, err = reader.Aggregate(reader.sc.AggregatesCache, &aggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if agg.Aggregates.TransactionCount != 1 {
+		t.Errorf("Expected %d txs", 1)
+	}
+	if agg.StartTime != startTime || agg.EndTime != endTime {
+		t.Error("aggregate tx invalid")
 	}
 }
 
@@ -205,6 +386,8 @@ func newTestIndex(t *testing.T) (*Reader, func()) {
 	}
 
 	sc := &servicesctrl.Control{Log: logging.NoLog{}, Services: conf, Chains: chains}
+	sc.AggregatesCache = caching.NewAggregatesCache()
+	sc.AggregatesCache.InitCacheStorage(chains)
 	conns, err := sc.Database()
 	if err != nil {
 		t.Fatal("Failed to create connections:", err.Error())

--- a/services/indexes/avm/avm_test.go
+++ b/services/indexes/avm/avm_test.go
@@ -36,9 +36,7 @@ import (
 	"github.com/chain4travel/magellan/utils"
 )
 
-var (
-	testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
-)
+var testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
 
 func TestIndexBootstrap(t *testing.T) {
 	conns, writer, reader, closeFn := newTestIndex(t, testXChainID)

--- a/services/indexes/cvm/cvm_test.go
+++ b/services/indexes/cvm/cvm_test.go
@@ -32,9 +32,7 @@ import (
 	"github.com/chain4travel/magellan/utils"
 )
 
-var (
-	testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
-)
+var testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
 
 func newTestIndex(t *testing.T, networkID uint32, chainID ids.ID) (*utils.Connections, *Writer, func()) {
 	logConf := logging.DefaultConfig

--- a/services/indexes/pvm/pvm_test.go
+++ b/services/indexes/pvm/pvm_test.go
@@ -28,9 +28,7 @@ import (
 	"github.com/chain4travel/magellan/utils"
 )
 
-var (
-	testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
-)
+var testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
 
 func TestBootstrap(t *testing.T) {
 	conns, w, r, closeFn := newTestIndex(t, 12345, ChainID)


### PR DESCRIPTION
Hey guys.

Just some info here:

I am firing up the scheduler within the magelland.go right before the execute command.

It could be done better (either with a separate parameter and starting it up as a separate service or with a health check in order to avoid the time threshold i have added in order to avoid errors which i do not like 100% tbh). We can of course refactor it in the future. If you need any clarification let me know.

I tried to be aligned with the existing implementation so as not to break anything that is already working.

The 2 endpoints Aggregate and TxFeesAggregate are ONLY originally called from the scheduler where the cacheUpd parameter exists(that i added). If not everything is retrieved from the cache.

In this case, based on the input dates(starttime , endtime) the implementation can understand if we refer to day, week or month and retrieve directly from the cache.

If we are using these endpoints for other purposes where we need the specific date ranges let me know so us to alter it accordingly.

Thanks!