### PR TITLE
TECH-251: query refactor

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_PASS }}
       - name: Push to Docker Hub
         uses: docker/build-push-action@v2
         with:

--- a/services/indexes/avax/reader_list_cblocks.go
+++ b/services/indexes/avax/reader_list_cblocks.go
@@ -117,6 +117,7 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 			"status",
 			"gas_used",
 			"gas_price",
+			"block_idx",
 		).
 			From(db.TableCvmTransactionsTxdata).
 			LeftJoin(dbr.I(db.TableCvmAccounts).As("F"), "id_from_addr = F.id").
@@ -135,6 +136,7 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 		}
 
 		if len(p.CAddresses) > 0 {
+			sq = sq.Distinct()
 			addressesSQL := strings.Join(p.CAddresses, "','")
 			addressesSQL = "'" + addressesSQL + "'"
 			sq = sq.From("(select id from cvm_accounts where address in (" + addressesSQL + ") ) sub,cvm_transactions_txdata")


### PR DESCRIPTION
Changed the structure of the query by removing the multiple 'in' closes and preventing unnecessary parsing of the same table which increased the cost of the hash join with the master table.