### PR TITLE
TECH-280: Time filtering functionality and pagination on cblocks

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_PASS }}
       - name: Push to Docker Hub
         uses: docker/build-push-action@v2
         with:

--- a/api/v2.go
+++ b/api/v2.go
@@ -26,8 +26,10 @@ import (
 	"github.com/gocraft/web"
 )
 
-const DefaultLimit = 1000
-const DefaultOffsetLimit = 10000
+const (
+	DefaultLimit       = 1000
+	DefaultOffsetLimit = 10000
+)
 
 type V2Context struct {
 	*Context
@@ -35,23 +37,27 @@ type V2Context struct {
 	chainID *ids.ID
 }
 
-const MetricCount = "api_count"
-const MetricMillis = "api_millis"
+const (
+	MetricCount  = "api_count"
+	MetricMillis = "api_millis"
+)
 
-const MetricTransactionsCount = "api_transactions_count"
-const MetricTransactionsMillis = "api_transactions_millis"
-const MetricCTransactionsCount = "api_ctransactions_count"
-const MetricCTransactionsMillis = "api_ctransactions_millis"
-const MetricAddressesCount = "api_addresses_count"
-const MetricAddressesMillis = "api_addresses_millis"
-const MetricAddressChainsCount = "api_address_chains_count"
-const MetricAddressChainsMillis = "api_address_chains_millis"
-const MetricAggregateCount = "api_aggregate_count"
-const MetricAggregateMillis = "api_aggregate_millis"
-const MetricAssetCount = "api_asset_count"
-const MetricAssetMillis = "api_asset_millis"
-const MetricSearchCount = "api_search_count"
-const MetricSearchMillis = "api_search_millis"
+const (
+	MetricTransactionsCount   = "api_transactions_count"
+	MetricTransactionsMillis  = "api_transactions_millis"
+	MetricCTransactionsCount  = "api_ctransactions_count"
+	MetricCTransactionsMillis = "api_ctransactions_millis"
+	MetricAddressesCount      = "api_addresses_count"
+	MetricAddressesMillis     = "api_addresses_millis"
+	MetricAddressChainsCount  = "api_address_chains_count"
+	MetricAddressChainsMillis = "api_address_chains_millis"
+	MetricAggregateCount      = "api_aggregate_count"
+	MetricAggregateMillis     = "api_aggregate_millis"
+	MetricAssetCount          = "api_asset_count"
+	MetricAssetMillis         = "api_asset_millis"
+	MetricSearchCount         = "api_search_count"
+	MetricSearchMillis        = "api_search_millis"
+)
 
 // AddV2Routes mounts a V2 API router at the given path, displaying the given
 // indexBytes at the root. If chainID is not nil the handlers run in v1
@@ -366,11 +372,6 @@ func (c *V2Context) ListCBlocks(w web.ResponseWriter, r *web.Request) {
 
 	if p.ListParams.Offset > DefaultOffsetLimit {
 		c.WriteErr(w, 400, fmt.Errorf("invalid block offset"))
-		return
-	}
-
-	if p.TxOffset > DefaultOffsetLimit {
-		c.WriteErr(w, 400, fmt.Errorf("invalid tx offset"))
 		return
 	}
 

--- a/models/collections.go
+++ b/models/collections.go
@@ -102,9 +102,6 @@ type CTransactionDataBase struct {
 }
 
 type CBlockList struct {
-	BlockCount       uint64 `json:"blockCount"`
-	TransactionCount uint64 `json:"transactionCount"`
-
 	Blocks       []*CBlockHeaderBase     `json:"blocks"`
 	Transactions []*CTransactionDataBase `json:"transactions"`
 }

--- a/services/indexes/avax/reader_list_cblocks.go
+++ b/services/indexes/avax/reader_list_cblocks.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/chain4travel/magellan/cfg"
@@ -31,31 +32,45 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 		return nil, err
 	}
 
+	var sq *dbr.SelectStmt
 	result := models.CBlockList{}
 	// Get count of blocks
-	err = dbRunner.Select("COUNT(block)").
-		From(db.TableCvmBlocks).
-		LoadOneContext(ctx, &result.BlockCount)
+	sq = dbRunner.Select("COUNT(block)").
+		From(db.TableCvmBlocks)
+
+	if p.ListParams.StartTimeProvided {
+		sq = sq.Where("created_at >= ?", p.ListParams.StartTime)
+	}
+	if p.ListParams.EndTimeProvided {
+		sq = sq.Where("created_at < ?", p.ListParams.EndTime)
+	}
+
+	err = sq.LoadOneContext(ctx, &result.BlockCount)
 	if err != nil {
 		return nil, err
 	}
 
 	// get count of TX
-	var sq *dbr.SelectStmt
-	if len(p.CAddresses) > 0 {
+	if len(p.CAddresses) > 0 && !p.ListParams.StartTimeProvided && !p.ListParams.EndTimeProvided {
 		sq = dbRunner.Select("tx_count").
 			From(db.TableCvmAccounts).
 			Where("address in ?", p.CAddresses)
 	} else {
 		sq = dbRunner.Select("COUNT(block_idx)").
 			From(db.TableCvmTransactionsTxdata)
+		if p.ListParams.StartTimeProvided {
+			sq = sq.Where("created_at >= ?", p.ListParams.StartTime)
+		}
+		if p.ListParams.EndTimeProvided {
+			sq = sq.Where("created_at < ?", p.ListParams.EndTime)
+		}
 	}
 	err = sq.LoadOneContext(ctx, &result.TransactionCount)
 	if err != nil {
 		return nil, err
 	}
 
-	// Setp 1 get Block headers
+	// Step 1 get Block headers
 	if p.ListParams.Limit > 0 {
 		var blockList []*db.CvmBlocks
 
@@ -64,8 +79,14 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 			"atomic_tx",
 			"serialization",
 		).
-			From(db.TableCvmBlocks).
-			Limit(uint64(p.ListParams.Limit))
+			From(db.TableCvmBlocks)
+
+		if p.ListParams.StartTimeProvided {
+			sq = sq.Where("created_at >= ?", p.ListParams.StartTime)
+		}
+		if p.ListParams.EndTimeProvided {
+			sq = sq.Where("created_at < ?", p.ListParams.EndTime)
+		}
 
 		switch {
 		case p.BlockStart != nil:
@@ -78,6 +99,7 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 			sq = sq.OrderDesc("block")
 		}
 
+		sq = sq.Paginate(uint64(p.ListParams.Offset), uint64(p.ListParams.Limit))
 		_, err = sq.LoadContext(ctx, &blockList)
 		if err != nil {
 			return nil, err
@@ -94,7 +116,7 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 		}
 	}
 
-	// Setp 2 get Transactions
+	// Step 2 get Transactions
 	if p.TxLimit > 0 {
 		var txList []*struct {
 			Serialization []byte
@@ -116,10 +138,17 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 			"status",
 			"gas_used",
 			"gas_price",
+			"block_idx",
 		).
 			From(db.TableCvmTransactionsTxdata).
-			LeftJoin(dbr.I(db.TableCvmAccounts).As("F"), "id_from_addr = id").
-			Limit(uint64(p.TxLimit))
+			LeftJoin(dbr.I(db.TableCvmAccounts).As("F"), "id_from_addr = F.id")
+
+		if p.ListParams.StartTimeProvided {
+			sq = sq.Where("created_at >= ?", p.ListParams.StartTime)
+		}
+		if p.ListParams.EndTimeProvided {
+			sq = sq.Where("created_at < ?", p.ListParams.EndTime)
+		}
 
 		switch {
 		case p.BlockStart != nil:
@@ -134,10 +163,14 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 		}
 
 		if len(p.CAddresses) > 0 {
-			subSel := dbr.Select("id").From(db.TableCvmAccounts).Where("address in ?", p.CAddresses)
-			sq = sq.Where("id_from_addr in ? OR id_to_addr in ?", subSel, subSel)
+			sq = sq.Distinct()
+			addressesSQL := strings.Join(p.CAddresses, "','")
+			addressesSQL = "'" + addressesSQL + "'"
+			sq = sq.From("(select id from cvm_accounts where address in (" + addressesSQL + ") ) sub,cvm_transactions_txdata")
+			sq = sq.Where("(id_from_addr=sub.id  OR id_to_addr=sub.id)")
 		}
 
+		sq = sq.Paginate(uint64(p.TxOffset), uint64(p.TxLimit))
 		_, err = sq.LoadContext(ctx, &txList)
 		if err != nil {
 			return nil, err

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -345,7 +345,6 @@ func (p *ListCTransactionsParams) Apply(b *dbr.SelectBuilder) *dbr.SelectBuilder
 type ListCBlocksParams struct {
 	ListParams ListParams
 	TxLimit    int
-	TxOffset   int
 	CAddresses []string
 	BlockStart *big.Int
 	BlockEnd   *big.Int
@@ -353,7 +352,7 @@ type ListCBlocksParams struct {
 }
 
 func (p *ListCBlocksParams) ForValues(version uint8, q url.Values) (err error) {
-	err = p.ListParams.ForValuesAllowOffset(version, q)
+	err = p.ListParams.ForValues(version, q)
 	if err != nil {
 		return err
 	}
@@ -362,14 +361,6 @@ func (p *ListCBlocksParams) ForValues(version uint8, q url.Values) (err error) {
 	limits, ok := q[KeyLimit]
 	if ok && len(limits) > 1 {
 		if p.TxLimit, err = strconv.Atoi(limits[1]); err != nil {
-			return err
-		}
-	}
-
-	p.TxOffset = 0
-	offsets, ok := q[KeyOffset]
-	if ok && len(offsets) > 1 {
-		if p.TxOffset, err = strconv.Atoi(offsets[1]); err != nil {
 			return err
 		}
 	}

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -366,6 +366,14 @@ func (p *ListCBlocksParams) ForValues(version uint8, q url.Values) (err error) {
 		}
 	}
 
+	p.TxOffset = 0
+	offsets, ok := q[KeyOffset]
+	if ok && len(offsets) > 1 {
+		if p.TxOffset, err = strconv.Atoi(offsets[1]); err != nil {
+			return err
+		}
+	}
+
 	addressStrs := q[KeyAddress]
 	for _, addressStr := range addressStrs {
 		if !strings.HasPrefix(addressStr, "0x") {


### PR DESCRIPTION
### Description:

The purpose of this [epic](https://c4t.atlassian.net/browse/TECH-280) is to add the functionality of c-chain time filtering on magellan api, in order for the block explorer to be able to fetch blocks/transactions within a specific time frame as described in this [task](https://c4t.atlassian.net/browse/TECH-230). This functionality will be applied to the cblocks query.

### Changes:

- Removed `offset` param from cblocks query. 
- Removed `TxCount` and `BlockCount` from cblocks query response
- Added date filters to both block and transaction parts of the cblocks query.
