### PR TITLE
TECH-179: Aggregates caching mechanism

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -19,13 +19,13 @@ import (
 	"time"
 
 	"github.com/chain4travel/caminogo/ids"
+	"github.com/chain4travel/magellan/caching"
 	"github.com/chain4travel/magellan/cfg"
 	"github.com/chain4travel/magellan/models"
 	"github.com/chain4travel/magellan/services"
 	"github.com/chain4travel/magellan/services/indexes/avax"
 	"github.com/chain4travel/magellan/servicesctrl"
 	"github.com/chain4travel/magellan/stream/consumers"
-	"github.com/chain4travel/magellan/utils"
 	"github.com/gocraft/web"
 )
 
@@ -109,8 +109,8 @@ func newRouter(sc *servicesctrl.Control, conf cfg.Config) (*web.Router, error) {
 		return nil, err
 	}
 
-	cache := utils.NewCache()
-	delayCache := utils.NewDelayCache(cache)
+	cache := caching.NewCache()
+	delayCache := caching.NewDelayCache(cache)
 
 	consumersmap := make(map[string]services.Consumer)
 	for chid, chain := range conf.Chains {

--- a/api/v2.go
+++ b/api/v2.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/chain4travel/caminogo/ids"
+	"github.com/chain4travel/magellan/caching"
 	"github.com/chain4travel/magellan/cfg"
 	"github.com/chain4travel/magellan/services/indexes/params"
 	"github.com/chain4travel/magellan/utils"
@@ -155,7 +156,7 @@ func (c *V2Context) Search(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		Key: c.cacheKeyForParams("search", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return c.avaxReader.Search(ctx, p, c.avaxAssetID)
@@ -180,10 +181,10 @@ func (c *V2Context) TxfeeAggregate(w web.ResponseWriter, r *web.Request) {
 
 	p.ChainIDs = params.ForValueChainID(c.chainID, p.ChainIDs)
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		Key: c.cacheKeyForParams("aggregate_txfee", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return c.avaxReader.TxfeeAggregate(ctx, p)
+			return c.avaxReader.TxfeeAggregate(c.sc.AggregatesCache, p)
 		},
 	})
 }
@@ -207,10 +208,10 @@ func (c *V2Context) Aggregate(w web.ResponseWriter, r *web.Request) {
 
 	p.ChainIDs = params.ForValueChainID(c.chainID, p.ChainIDs)
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		Key: c.cacheKeyForParams("aggregate", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return c.avaxReader.Aggregate(ctx, p, nil)
+			return c.avaxReader.Aggregate(c.sc.AggregatesCache, p)
 		},
 	})
 }
@@ -239,7 +240,7 @@ func (c *V2Context) ListTransactions(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 5 * time.Second,
 		Key: c.cacheKeyForParams("list_transactions", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -277,7 +278,7 @@ func (c *V2Context) ListTransactionsPost(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 5 * time.Second,
 		Key: c.cacheKeyForParams("list_transactions", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -303,7 +304,7 @@ func (c *V2Context) GetTransaction(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 5 * time.Second,
 		Key: c.cacheKeyForID("get_transaction", r.PathParams["id"]),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -334,7 +335,7 @@ func (c *V2Context) ListCTransactions(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 5 * time.Second,
 		Key: c.cacheKeyForParams("list_ctransactions", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -375,7 +376,7 @@ func (c *V2Context) ListCBlocks(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 5 * time.Second,
 		Key: c.cacheKeyForParams("list_cblocks", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -404,7 +405,7 @@ func (c *V2Context) ListAddresses(w web.ResponseWriter, r *web.Request) {
 	p.ChainIDs = params.ForValueChainID(c.chainID, p.ChainIDs)
 	p.ListParams.DisableCounting = true
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 5 * time.Second,
 		Key: c.cacheKeyForParams("list_addresses", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -439,7 +440,7 @@ func (c *V2Context) GetAddress(w web.ResponseWriter, r *web.Request) {
 	p.ListParams.DisableCounting = true
 	p.ChainIDs = params.ForValueChainID(c.chainID, p.ChainIDs)
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 1 * time.Second,
 		Key: c.cacheKeyForParams("get_address", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -465,7 +466,7 @@ func (c *V2Context) AddressChains(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 5 * time.Second,
 		Key: c.cacheKeyForParams("address_chains", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -496,7 +497,7 @@ func (c *V2Context) AddressChainsPost(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 5 * time.Second,
 		Key: c.cacheKeyForParams("address_chains", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -522,7 +523,7 @@ func (c *V2Context) ListOutputs(w web.ResponseWriter, r *web.Request) {
 
 	p.ChainIDs = params.ForValueChainID(c.chainID, p.ChainIDs)
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 5 * time.Second,
 		Key: c.cacheKeyForParams("list_outputs", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -546,7 +547,7 @@ func (c *V2Context) GetOutput(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		Key: c.cacheKeyForID("get_output", r.PathParams["id"]),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return c.avaxReader.GetOutput(ctx, id)
@@ -574,7 +575,7 @@ func (c *V2Context) ListAssets(w web.ResponseWriter, r *web.Request) {
 		c.WriteErr(w, 400, err)
 		return
 	}
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		Key: c.cacheKeyForParams("list_assets", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return c.avaxReader.ListAssets(ctx, p, nil)
@@ -601,7 +602,7 @@ func (c *V2Context) GetAsset(w web.ResponseWriter, r *web.Request) {
 	id := r.PathParams["id"]
 	p.PathParamID = id
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		Key: c.cacheKeyForParams("get_asset", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return c.avaxReader.GetAsset(ctx, p, id)
@@ -627,7 +628,7 @@ func (c *V2Context) ListBlocks(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 5 * time.Second,
 		Key: c.cacheKeyForParams("list_blocks", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
@@ -651,7 +652,7 @@ func (c *V2Context) GetBlock(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	c.WriteCacheable(w, utils.Cacheable{
+	c.WriteCacheable(w, caching.Cacheable{
 		Key: c.cacheKeyForID("get_block", r.PathParams["id"]),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return c.avaxReader.GetBlock(ctx, id)

--- a/api/v2.go
+++ b/api/v2.go
@@ -610,9 +610,7 @@ func (c *V2Context) GetAsset(w web.ResponseWriter, r *web.Request) {
 	})
 }
 
-//
 // PVM
-//
 func (c *V2Context) ListBlocks(w web.ResponseWriter, r *web.Request) {
 	collectors := utils.NewCollectors(
 		utils.NewCounterObserveMillisCollect(MetricMillis),

--- a/caching/aggregates_cache.go
+++ b/caching/aggregates_cache.go
@@ -1,0 +1,577 @@
+package caching
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net/url"
+	"time"
+
+	"github.com/chain4travel/magellan/cfg"
+	"github.com/chain4travel/magellan/models"
+	"github.com/chain4travel/magellan/services/indexes/params"
+	"github.com/chain4travel/magellan/utils"
+	"github.com/gocraft/dbr/v2"
+)
+
+const (
+	MaxAggregateIntervalCount = 20000
+)
+
+var (
+	ErrAggregateIntervalCountTooLarge = errors.New("requesting too many intervals")
+	ErrFailedToParseStringAsBigInt    = errors.New("failed to parse string to big.Int")
+)
+
+type AggregatesCache interface {
+	GetAggregateTransactionsMap() map[string]map[string]uint64
+	GetAggregateFeesMap() map[string]map[string]uint64
+	InitCacheStorage(cfg.Chains)
+	GetAggregatesFeesAndUpdate(map[string]cfg.Chain, *utils.Connections, string, time.Time, time.Time, string) error
+	GetAggregatesAndUpdate(map[string]cfg.Chain, *utils.Connections, string, time.Time, time.Time, string) error
+}
+
+type aggregatesCache struct {
+	aggregateTransactionsMap map[string]map[string]uint64
+	aggregateFeesMap         map[string]map[string]uint64
+}
+
+func NewAggregatesCache() AggregatesCache {
+	return &aggregatesCache{
+		aggregateTransactionsMap: make(map[string]map[string]uint64),
+		aggregateFeesMap:         make(map[string]map[string]uint64),
+	}
+}
+
+func (ac *aggregatesCache) GetAggregateTransactionsMap() map[string]map[string]uint64 {
+	return ac.aggregateTransactionsMap
+}
+
+func (ac *aggregatesCache) GetAggregateFeesMap() map[string]map[string]uint64 {
+	return ac.aggregateFeesMap
+}
+
+func (ac *aggregatesCache) InitCacheStorage(chains cfg.Chains) {
+	aggregateTransMap := ac.aggregateTransactionsMap
+	aggregateFeesMap := ac.aggregateFeesMap
+	for id := range chains {
+		aggregateTransMap[id] = map[string]uint64{}
+		aggregateFeesMap[id] = map[string]uint64{}
+
+		// we initialize the value for all 3 chains
+		aggregateTransMap[id]["day"] = 0
+		aggregateTransMap[id]["week"] = 0
+		aggregateTransMap[id]["month"] = 0
+
+		// we initialize the value for all 3 chains also here
+		aggregateFeesMap[id]["day"] = 0
+		aggregateFeesMap[id]["week"] = 0
+		aggregateFeesMap[id]["month"] = 0
+	}
+}
+
+//gocyclo:ignore
+func (ac *aggregatesCache) GetAggregatesAndUpdate(chains map[string]cfg.Chain, conns *utils.Connections, chainid string, startTime time.Time, endTime time.Time, rangeKeyType string) error {
+	chainIds := []string{chainid}
+	// Validate params and set defaults if necessary
+	if startTime.IsZero() {
+		var err error
+		startTime, err = getFirstTransactionTime(conns, chainIds)
+		if err != nil {
+			return err
+		}
+	}
+
+	intervals := models.AggregatesList{}
+	urlv := url.Values{}
+	assetID, err := params.GetQueryID(urlv, params.KeyAssetID)
+	if err != nil {
+		return err
+	}
+	intervalSize, err := params.GetQueryInterval(urlv, params.KeyIntervalSize)
+	if err != nil {
+		return err
+	}
+
+	// Ensure the interval count requested isn't too large
+	intervalSeconds := int64(intervalSize.Seconds())
+	requestedIntervalCount := 0
+	if intervalSeconds != 0 {
+		requestedIntervalCount = int(math.Ceil(endTime.Sub(startTime).Seconds() / intervalSize.Seconds()))
+		if requestedIntervalCount > MaxAggregateIntervalCount {
+			return ErrAggregateIntervalCountTooLarge
+		}
+		if requestedIntervalCount < 1 {
+			requestedIntervalCount = 1
+		}
+	}
+
+	// Split chains
+	var avmChains, cvmChains []string
+	if len(chainIds) == 0 {
+		for id, chain := range chains {
+			switch chain.VMType {
+			case models.CVMName:
+				cvmChains = append(cvmChains, id)
+			default:
+				avmChains = append(avmChains, id)
+			}
+		}
+	} else {
+		for _, id := range chainIds {
+			chain, exist := chains[id]
+			if exist {
+				switch chain.VMType {
+				case models.CVMName:
+					cvmChains = append(cvmChains, id)
+				default:
+					avmChains = append(avmChains, id)
+				}
+			}
+		}
+	}
+
+	var dbRunner *dbr.Session
+
+	if conns != nil {
+		dbRunner = conns.DB().NewSessionForEventReceiver(conns.Stream().NewJob("get_transaction_aggregates_histogram"))
+	} else {
+		dbRunner, err = conns.DB().NewSession("get_transaction_aggregates_histogram", cfg.RequestTimeout)
+		if err != nil {
+			return err
+		}
+	}
+
+	var builder *dbr.SelectStmt
+
+	if len(avmChains) > 0 {
+		columns := []string{
+			"COALESCE(SUM(avm_outputs.amount), 0) AS transaction_volume",
+			"COUNT(DISTINCT(avm_outputs.transaction_id)) AS transaction_count",
+			"COUNT(DISTINCT(avm_output_addresses.address)) AS address_count",
+			"COUNT(DISTINCT(avm_outputs.asset_id)) AS asset_count",
+			"COUNT(avm_outputs.id) AS output_count",
+		}
+
+		if requestedIntervalCount > 0 {
+			columns = append(columns, fmt.Sprintf(
+				"FLOOR((UNIX_TIMESTAMP(avm_outputs.created_at)-%d) / %d) AS interval_id",
+				startTime.Unix(),
+				intervalSeconds))
+		}
+
+		builder = dbRunner.
+			Select(columns...).
+			From("avm_outputs").
+			LeftJoin("avm_output_addresses", "avm_output_addresses.output_id = avm_outputs.id").
+			Where("avm_outputs.created_at >= ?", startTime).
+			Where("avm_outputs.created_at < ?", endTime)
+
+		if len(chainIds) != 0 {
+			builder.Where("avm_outputs.chain_id IN ?", avmChains)
+		}
+
+		if assetID != nil {
+			builder.Where("avm_outputs.asset_id = ?", assetID.String())
+		}
+
+		if requestedIntervalCount > 0 {
+			builder.
+				GroupBy("interval_id").
+				OrderAsc("interval_id").
+				Limit(uint64(requestedIntervalCount))
+		}
+
+		_, err = builder.Load(&intervals)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(cvmChains) > 0 {
+		columns := []string{
+			"COALESCE(SUM(cvm_transactions_txdata.amount), 0) AS transaction_volume",
+			"COUNT(cvm_transactions_txdata.hash) AS transaction_count",
+			"COUNT(DISTINCT(cvm_transactions_txdata.id_from_addr)) AS address_count",
+			"1 AS asset_count",
+			"0 AS output_count",
+		}
+
+		if requestedIntervalCount > 0 {
+			columns = append(columns, fmt.Sprintf(
+				"FLOOR((UNIX_TIMESTAMP(cvm_transactions_txdata.created_at)-%d) / %d) AS interval_id",
+				startTime.Unix(),
+				intervalSeconds))
+		}
+
+		builder = dbRunner.
+			Select(columns...).
+			From("cvm_transactions_txdata")
+
+		if len(chainIds) != 0 {
+			builder.Join("cvm_blocks", "cvm_blocks.block = cvm_transactions_txdata.block").
+				Where("cvm_blocks.chain_id IN ?", cvmChains)
+		}
+
+		builder.Where("cvm_transactions_txdata.created_at >= ?", startTime).
+			Where("cvm_transactions_txdata.created_at < ?", endTime)
+
+		if requestedIntervalCount > 0 {
+			builder.
+				GroupBy("interval_id").
+				OrderAsc("interval_id").
+				Limit(uint64(requestedIntervalCount))
+		}
+
+		cvmIntervals := models.AggregatesList{}
+
+		_, err = builder.Load(&cvmIntervals)
+		if err != nil {
+			return err
+		}
+
+		if len(intervals) == 0 {
+			intervals = cvmIntervals
+		} else {
+			models.MergeAggregates(intervals.MergeList(), cvmIntervals.MergeList())
+		}
+	}
+
+	// If no intervals were requested then the total aggregate is equal to the
+	// first (and only) interval, and we're done
+	if requestedIntervalCount == 0 {
+		// This check should never fail if the SQL query is correct, but added for
+		// robustness to prevent panics if the invariant does not hold.
+		if len(intervals) > 0 {
+			intervals[0].StartTime = startTime
+			intervals[0].EndTime = endTime
+			aggs := &models.AggregatesHistogram{
+				Aggregates: intervals[0],
+				StartTime:  startTime,
+				EndTime:    endTime,
+			}
+			ac.aggregateTransactionsMap[chainid][rangeKeyType] = aggs.Aggregates.TransactionCount
+			return nil
+		}
+		aggs := &models.AggregatesHistogram{
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+		ac.aggregateTransactionsMap[chainid][rangeKeyType] = aggs.Aggregates.TransactionCount
+		return nil
+	}
+
+	// We need to return multiple intervals so build them now.
+	// Intervals without any data will not return anything so we pad our results
+	// with empty aggregates.
+	//
+	// We also add the start and end times of each interval to that interval
+	aggs := &models.AggregatesHistogram{IntervalSize: intervalSize}
+
+	var startTS int64
+	timesForInterval := func(intervalIdx int) (time.Time, time.Time) {
+		startTS = startTime.Unix() + (int64(intervalIdx) * intervalSeconds)
+		return time.Unix(startTS, 0).UTC(),
+			time.Unix(startTS+intervalSeconds-1, 0).UTC()
+	}
+
+	padTo := func(slice []models.Aggregates, to int) []models.Aggregates {
+		for i := len(slice); i < to; i = len(slice) {
+			slice = append(slice, models.Aggregates{IntervalID: i})
+			slice[i].StartTime, slice[i].EndTime = timesForInterval(i)
+		}
+		return slice
+	}
+
+	// Collect the overall counts and pad the intervals to include empty intervals
+	// which are not returned by the db
+	aggs.Aggregates = models.Aggregates{StartTime: startTime, EndTime: endTime}
+	var (
+		bigIntFromStringOK bool
+		totalVolume        = big.NewInt(0)
+		intervalVolume     = big.NewInt(0)
+	)
+
+	// Add each interval, but first pad up to that interval's index
+	aggs.Intervals = make([]models.Aggregates, 0, requestedIntervalCount)
+	for _, interval := range intervals {
+		// Pad up to this interval's position
+		aggs.Intervals = padTo(aggs.Intervals, interval.IntervalID)
+
+		// Format this interval
+		interval.StartTime, interval.EndTime = timesForInterval(interval.IntervalID)
+
+		// Parse volume into a big.Int
+		_, bigIntFromStringOK = intervalVolume.SetString(string(interval.TransactionVolume), 10)
+		if !bigIntFromStringOK {
+			return ErrFailedToParseStringAsBigInt
+		}
+
+		// Add to the overall aggregates counts
+		totalVolume.Add(totalVolume, intervalVolume)
+		aggs.Aggregates.TransactionCount += interval.TransactionCount
+		aggs.Aggregates.OutputCount += interval.OutputCount
+		aggs.Aggregates.AddressCount += interval.AddressCount
+		aggs.Aggregates.AssetCount += interval.AssetCount
+
+		// Add to the list of intervals
+		aggs.Intervals = append(aggs.Intervals, interval)
+	}
+	// Add total aggregated token amounts
+	aggs.Aggregates.TransactionVolume = models.TokenAmount(totalVolume.String())
+
+	// Add any missing trailing intervals
+	aggs.Intervals = padTo(aggs.Intervals, requestedIntervalCount)
+
+	aggs.StartTime = startTime
+	aggs.EndTime = endTime
+	ac.aggregateTransactionsMap[chainid][rangeKeyType] = aggs.Aggregates.TransactionCount
+	return nil
+}
+
+//gocyclo:ignore
+func (ac *aggregatesCache) GetAggregatesFeesAndUpdate(chains map[string]cfg.Chain, conns *utils.Connections, chainid string, startTime time.Time, endTime time.Time, rangeKeyType string) error {
+	chainIds := []string{chainid}
+	// Validate params and set defaults if necessary
+	if startTime.IsZero() {
+		var err error
+		startTime, err = getFirstTransactionTime(conns, chainIds)
+		if err != nil {
+			return err
+		}
+	}
+
+	intervals := models.TxfeeAggregatesList{}
+	urlv := url.Values{}
+	intervalSize, err := params.GetQueryInterval(urlv, params.KeyIntervalSize)
+	if err != nil {
+		return err
+	}
+
+	// Ensure the interval count requested isn't too large
+	intervalSeconds := int64(intervalSize.Seconds())
+	requestedIntervalCount := 0
+	if intervalSeconds != 0 {
+		requestedIntervalCount = int(math.Ceil(endTime.Sub(startTime).Seconds() / intervalSize.Seconds()))
+		if requestedIntervalCount > MaxAggregateIntervalCount {
+			return ErrAggregateIntervalCountTooLarge
+		}
+		if requestedIntervalCount < 1 {
+			requestedIntervalCount = 1
+		}
+	}
+
+	// Split chains
+	var avmChains, cvmChains []string
+	if len(chainIds) == 0 {
+		for id, chain := range chains {
+			switch chain.VMType {
+			case models.CVMName:
+				cvmChains = append(cvmChains, id)
+			default:
+				avmChains = append(avmChains, id)
+			}
+		}
+	} else {
+		for _, id := range chainIds {
+			chain, exist := chains[id]
+			if exist {
+				switch chain.VMType {
+				case models.CVMName:
+					cvmChains = append(cvmChains, id)
+				default:
+					avmChains = append(avmChains, id)
+				}
+			}
+		}
+	}
+
+	// Build the query and load the base data
+	dbRunner, err := conns.DB().NewSession("get_txfee_aggregates_histogram", cfg.RequestTimeout)
+	if err != nil {
+		return err
+	}
+
+	var builder *dbr.SelectStmt
+
+	if len(avmChains) > 0 {
+		columns := []string{
+			"CAST(COALESCE(SUM(avm_transactions.txfee), 0) AS UNSIGNED) AS txfee",
+		}
+
+		if requestedIntervalCount > 0 {
+			columns = append(columns, fmt.Sprintf(
+				"FLOOR((UNIX_TIMESTAMP(avm_transactions.created_at)-%d) / %d) AS interval_id",
+				startTime.Unix(),
+				intervalSeconds))
+		}
+
+		builder = dbRunner.
+			Select(columns...).
+			From("avm_transactions").
+			Where("avm_transactions.created_at >= ?", startTime).
+			Where("avm_transactions.created_at < ?", endTime)
+
+		if requestedIntervalCount > 0 {
+			builder.
+				GroupBy("interval_id").
+				OrderAsc("interval_id").
+				Limit(uint64(requestedIntervalCount))
+		}
+
+		if len(chainIds) != 0 {
+			builder.Where("avm_transactions.chain_id IN ?", chainIds)
+		}
+
+		_, err = builder.Load(&intervals)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(cvmChains) > 0 {
+		columns := []string{
+			"CAST(COALESCE(SUM((cvm_transactions_txdata.gas_price / 1000000000) * cvm_transactions_txdata.gas_used), 0) AS UNSIGNED) AS txfee",
+		}
+
+		if requestedIntervalCount > 0 {
+			columns = append(columns, fmt.Sprintf(
+				"FLOOR((UNIX_TIMESTAMP(cvm_transactions_txdata.created_at)-%d) / %d) AS interval_id",
+				startTime.Unix(),
+				intervalSeconds))
+		}
+
+		builder = dbRunner.
+			Select(columns...).
+			From("cvm_transactions_txdata").
+			Where("cvm_transactions_txdata.created_at >= ?", startTime).
+			Where("cvm_transactions_txdata.created_at < ?", endTime)
+
+		if requestedIntervalCount > 0 {
+			builder.
+				GroupBy("interval_id").
+				OrderAsc("interval_id").
+				Limit(uint64(requestedIntervalCount))
+		}
+
+		if len(chainIds) != 0 {
+			builder.
+				Join("cvm_blocks", "cvm_blocks.block = cvm_transactions_txdata.block").
+				Where("cvm_blocks.chain_id IN ?", cvmChains)
+		}
+
+		cvmIntervals := models.TxfeeAggregatesList{}
+
+		_, err = builder.Load(&cvmIntervals)
+		if err != nil {
+			return err
+		}
+
+		if len(intervals) == 0 {
+			intervals = cvmIntervals
+		} else {
+			models.MergeAggregates(intervals.MergeList(), cvmIntervals.MergeList())
+		}
+	}
+
+	// If no intervals were requested then the total aggregate is equal to the
+	// first (and only) interval, and we're done
+	if requestedIntervalCount == 0 {
+		// This check should never fail if the SQL query is correct, but added for
+		// robustness to prevent panics if the invariant does not hold.
+		if len(intervals) > 0 {
+			intervals[0].StartTime = startTime
+			intervals[0].EndTime = endTime
+			aggs := &models.TxfeeAggregatesHistogram{
+				TxfeeAggregates: intervals[0],
+				StartTime:       startTime,
+				EndTime:         endTime,
+			}
+			ac.aggregateFeesMap[chainid][rangeKeyType] = aggs.TxfeeAggregates.Txfee
+			return nil
+		}
+		aggs := &models.TxfeeAggregatesHistogram{
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+		ac.aggregateFeesMap[chainid][rangeKeyType] = aggs.TxfeeAggregates.Txfee
+		return nil
+	}
+
+	// We need to return multiple intervals so build them now.
+	// Intervals without any data will not return anything so we pad our results
+	// with empty aggregates.
+	//
+	// We also add the start and end times of each interval to that interval
+	aggs := &models.TxfeeAggregatesHistogram{IntervalSize: intervalSize}
+
+	var startTS int64
+	timesForInterval := func(intervalIdx int) (time.Time, time.Time) {
+		startTS = startTime.Unix() + (int64(intervalIdx) * intervalSeconds)
+		return time.Unix(startTS, 0).UTC(),
+			time.Unix(startTS+intervalSeconds-1, 0).UTC()
+	}
+
+	padTo := func(slice []models.TxfeeAggregates, to int) []models.TxfeeAggregates {
+		for i := len(slice); i < to; i = len(slice) {
+			slice = append(slice, models.TxfeeAggregates{IntervalID: i})
+			slice[i].StartTime, slice[i].EndTime = timesForInterval(i)
+		}
+		return slice
+	}
+
+	// Collect the overall counts and pad the intervals to include empty intervals
+	// which are not returned by the db
+	aggs.TxfeeAggregates = models.TxfeeAggregates{StartTime: startTime, EndTime: endTime}
+	var totalVolume uint64 = 0
+
+	// Add each interval, but first pad up to that interval's index
+	aggs.Intervals = make([]models.TxfeeAggregates, 0, requestedIntervalCount)
+	for _, interval := range intervals {
+		// Pad up to this interval's position
+		aggs.Intervals = padTo(aggs.Intervals, interval.IntervalID)
+
+		// Format this interval
+		interval.StartTime, interval.EndTime = timesForInterval(interval.IntervalID)
+
+		// Add to the overall aggregates counts
+		totalVolume += interval.Txfee
+
+		// Add to the list of intervals
+		aggs.Intervals = append(aggs.Intervals, interval)
+	}
+	// Add total aggregated token amounts
+	aggs.TxfeeAggregates.Txfee = totalVolume
+
+	// Add any missing trailing intervals
+	aggs.Intervals = padTo(aggs.Intervals, requestedIntervalCount)
+
+	aggs.StartTime = startTime
+	aggs.EndTime = endTime
+
+	ac.aggregateFeesMap[chainid][rangeKeyType] = aggs.TxfeeAggregates.Txfee
+	return nil
+}
+
+func getFirstTransactionTime(conns *utils.Connections, chainIDs []string) (time.Time, error) {
+	dbRunner, err := conns.DB().NewSession("get_first_transaction_time", cfg.RequestTimeout)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	var ts float64
+	builder := dbRunner.
+		Select("COALESCE(UNIX_TIMESTAMP(MIN(created_at)), 0)").
+		From("avm_transactions")
+
+	if len(chainIDs) > 0 {
+		builder.Where("avm_transactions.chain_id IN ?", chainIDs)
+	}
+
+	err = builder.LoadOne(&ts)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(int64(math.Floor(ts)), 0).UTC(), nil
+}

--- a/caching/aggregates_cache.go
+++ b/caching/aggregates_cache.go
@@ -223,6 +223,11 @@ func (ac *aggregatesCache) GetAggregatesAndUpdate(chains map[string]cfg.Chain, c
 			lastBlockValue.Block = firstBlockValue.Block
 		}
 
+		// handle edge case in case we do not have a transaction block during this range
+		if firstBlockValue.Block <= 0 {
+			lastBlockValue.Block = firstBlockValue.Block
+		}
+
 		// 3rd step: we obtain the count of the transactions based on the block range we acquired from the previous steps
 		// we will construct based on the block numbers the relevant block_idx filters since this is our main index in the cvm_transactions_txdata table
 		builder = dbRunner.
@@ -393,6 +398,11 @@ func (ac *aggregatesCache) GetAggregatesFeesAndUpdate(chains map[string]cfg.Chai
 		}
 
 		if lastBlockValue.Block <= firstBlockValue.Block {
+			lastBlockValue.Block = firstBlockValue.Block
+		}
+
+		// handle edge case in case we do not have a transaction block during this range
+		if firstBlockValue.Block <= 0 {
 			lastBlockValue.Block = firstBlockValue.Block
 		}
 

--- a/caching/cache.go
+++ b/caching/cache.go
@@ -1,7 +1,7 @@
 // (c) 2021, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package utils
+package caching
 
 import (
 	"context"
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/chain4travel/magellan/utils"
 )
 
 const (
@@ -48,11 +50,11 @@ type Cache interface {
 }
 
 type cacheContainer struct {
-	cache *LCache
+	cache *utils.LCache
 }
 
 func NewCache() Cache {
-	return &cacheContainer{cache: NewTTLMap()}
+	return &cacheContainer{cache: utils.NewTTLMap()}
 }
 
 func (c *cacheContainer) Get(_ context.Context, key string) ([]byte, error) {

--- a/caching/delay_cache.go
+++ b/caching/delay_cache.go
@@ -11,13 +11,14 @@
 // (c) 2021, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package utils
+package caching
 
 import (
 	"context"
 	"time"
 
 	"github.com/chain4travel/magellan/cfg"
+	"github.com/chain4travel/magellan/utils"
 )
 
 const (
@@ -33,12 +34,12 @@ type CacheJob struct {
 
 type DelayCache struct {
 	Cache  Cacher
-	Worker Worker
+	Worker utils.Worker
 }
 
 func NewDelayCache(cache Cacher) *DelayCache {
 	c := &DelayCache{Cache: cache}
-	c.Worker = NewWorker(WorkerQueueSize, WorkerThreadCount, c.Processor)
+	c.Worker = utils.NewWorker(WorkerQueueSize, WorkerThreadCount, c.Processor)
 	return c
 }
 

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -32,17 +32,48 @@ var (
 	ErrChainsConfigVMNotString     = errors.New("Chain config vm type is not a string")
 )
 
+type Aggregates struct {
+	AggregateMerge    uint64 `json:"AggregateMerge"`
+	StartTime         string `json:"startTime"`
+	EndTime           string `json:"endTime"`
+	TransactionVolume uint64 `json:"transactionVolume"`
+	TransactionCount  uint64 `json:"transactionCount"`
+	AddressCount      uint64 `json:"addressCount"`
+	OutputCount       uint64 `json:"outputCount"`
+	AssetCount        uint64 `json:"assetCount"`
+}
+
+type AggregatesMain struct {
+	Aggregates Aggregates `json:"aggregates,omitempty"`
+	StartTime  string     `json:"startTime"`
+	EndTime    string     `json:"endTime"`
+}
+
+type AggregatesFees struct {
+	AggregateMerge uint64 `json:"AggregateMerge"`
+	StartTime      string `json:"startTime"`
+	EndTime        string `json:"endTime"`
+	Txfee          uint64 `json:"txfee"`
+}
+
+type AggregatesFeesMain struct {
+	Aggregates AggregatesFees `json:"aggregates,omitempty"`
+	StartTime  string         `json:"startTime"`
+	EndTime    string         `json:"endTime"`
+}
+
 type Config struct {
-	NetworkID         uint32 `json:"networkID"`
-	Chains            `json:"chains"`
-	Services          `json:"services"`
-	MetricsListenAddr string `json:"metricsListenAddr"`
-	AdminListenAddr   string `json:"adminListenAddr"`
-	Features          map[string]struct{}
-	CchainID          string `json:"cchainId"`
-	CaminoNode        string `json:"caminoNode"`
-	NodeInstance      string `json:"nodeInstance"`
-	AP5Activation     uint64
+	NetworkID           uint32 `json:"networkID"`
+	Chains              `json:"chains"`
+	Services            `json:"services"`
+	MetricsListenAddr   string `json:"metricsListenAddr"`
+	AdminListenAddr     string `json:"adminListenAddr"`
+	Features            map[string]struct{}
+	CchainID            string `json:"cchainId"`
+	CaminoNode          string `json:"caminoNode"`
+	NodeInstance        string `json:"nodeInstance"`
+	CacheUpdateInterval uint64 `json:"cacheUpdateInterval"`
+	AP5Activation       uint64
 }
 
 type Chain struct {
@@ -132,9 +163,10 @@ func NewFromFile(filePath string) (*Config, error) {
 				RODSN:  dbrodsn,
 			},
 		},
-		CchainID:      v.GetString(keysStreamProducerCchainID),
-		CaminoNode:    v.GetString(keysStreamProducerCaminoNode),
-		NodeInstance:  v.GetString(keysStreamProducerNodeInstance),
-		AP5Activation: uint64(ap5Activation),
+		CchainID:            v.GetString(keysStreamProducerCchainID),
+		CaminoNode:          v.GetString(keysStreamProducerCaminoNode),
+		NodeInstance:        v.GetString(keysStreamProducerNodeInstance),
+		CacheUpdateInterval: uint64(v.GetInt(keysCacheUpdateInterval)),
+		AP5Activation:       uint64(ap5Activation),
 	}, nil
 }

--- a/cfg/commonu.go
+++ b/cfg/commonu.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file contains helper functions
+
+package cfg
+
+import (
+	"time"
+)
+
+func GetDatepartBasedOnDateParams(pStartTime time.Time, pEndTime time.Time) string {
+	differenceInDays := int64(pEndTime.Sub(pStartTime).Hours() / 24)
+
+	switch {
+	case differenceInDays <= 1:
+		return "day"
+	case differenceInDays > 1 && differenceInDays <= 7:
+		return "week"
+	case differenceInDays > 7:
+		return "month"
+	default:
+		return ""
+	}
+}

--- a/cfg/defaults.go
+++ b/cfg/defaults.go
@@ -15,6 +15,7 @@ package cfg
 
 const defaultJSON = `{
   "networkID": 1001,
+  "cacheUpdateInterval": "5",
   "logDirectory": "/tmp/magellan/logs",
   "listenAddr": ":8080",
   "chains": {},

--- a/cfg/globals.go
+++ b/cfg/globals.go
@@ -10,6 +10,7 @@ const (
 	RequestTimeout   = 15 * time.Second
 	HTTPWriteTimeout = 30 * time.Second
 	CacheTimeout     = 3 * time.Second
+	DBTimeout        = 2 * 60 * time.Second
 
 	DefaultConsumeProcessWriteTimeout = 5 * time.Minute
 

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -37,4 +37,6 @@ const (
 	keysStreamProducerNodeInstance = "nodeInstance"
 
 	keysStreamProducerCchainID = "cchainID"
+
+	keysCacheUpdateInterval = "cacheUpdateInterval"
 )

--- a/cmds/magelland/magelland.go
+++ b/cmds/magelland/magelland.go
@@ -34,7 +34,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 
-	oreliusRpc "github.com/chain4travel/magellan/rpc"
+	magellanRpc "github.com/chain4travel/magellan/rpc"
 	_ "github.com/golang-migrate/migrate/v4/database"
 	_ "github.com/golang-migrate/migrate/v4/database/mysql"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -147,7 +147,7 @@ func execute() error {
 					codec := json2.NewCodec()
 					rpcServer.RegisterCodec(codec, "application/json")
 					rpcServer.RegisterCodec(codec, "application/json;charset=UTF-8")
-					api := oreliusRpc.NewAPI(alog)
+					api := magellanRpc.NewAPI(alog)
 					if err := rpcServer.RegisterService(api, "api"); err != nil {
 						log.Fatalln("Failed to start admin listener", err.Error())
 					}

--- a/cmds/magelland/magelland.go
+++ b/cmds/magelland/magelland.go
@@ -18,22 +18,23 @@ import (
 	"github.com/chain4travel/caminogo/utils/logging"
 	"github.com/chain4travel/magellan/api"
 	"github.com/chain4travel/magellan/balance"
+	"github.com/chain4travel/magellan/caching"
 	"github.com/chain4travel/magellan/cfg"
 	"github.com/chain4travel/magellan/db"
 	"github.com/chain4travel/magellan/models"
-	oreliusRpc "github.com/chain4travel/magellan/rpc"
 	"github.com/chain4travel/magellan/services/rewards"
 	"github.com/chain4travel/magellan/servicesctrl"
 	"github.com/chain4travel/magellan/stream"
 	"github.com/chain4travel/magellan/stream/consumers"
 	"github.com/chain4travel/magellan/utils"
 	"github.com/go-sql-driver/mysql"
+	"github.com/golang-migrate/migrate/v4"
 	"github.com/gorilla/rpc/v2"
 	"github.com/gorilla/rpc/v2/json2"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 
-	"github.com/golang-migrate/migrate/v4"
+	oreliusRpc "github.com/chain4travel/magellan/rpc"
 	_ "github.com/golang-migrate/migrate/v4/database"
 	_ "github.com/golang-migrate/migrate/v4/database/mysql"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -86,7 +87,8 @@ func execute() error {
 		configFile         = func() *string { s := ""; return &s }()
 		replayqueuesize    = func() *int { i := defaultReplayQueueSize; return &i }()
 		replayqueuethreads = func() *int { i := defaultReplayQueueThreads; return &i }()
-		cmd                = &cobra.Command{Use: rootCmdUse, Short: rootCmdDesc, Long: rootCmdDesc,
+		cmd                = &cobra.Command{
+			Use: rootCmdUse, Short: rootCmdDesc, Long: rootCmdDesc,
 			PersistentPreRun: func(cmd *cobra.Command, args []string) {
 				c, err := cfg.NewFromFile(*configFile)
 				if err != nil {
@@ -121,6 +123,7 @@ func execute() error {
 				serviceControl.Features = c.Features
 				persist := db.NewPersist()
 				serviceControl.BalanceManager = balance.NewManager(persist, serviceControl)
+				serviceControl.AggregatesCache = caching.NewAggregatesCache()
 				err = serviceControl.Init(c.NetworkID)
 				if err != nil {
 					log.Fatalln("Failed to create service control", ":", err.Error())
@@ -189,6 +192,12 @@ func createAPICmds(sc *servicesctrl.Control, config *cfg.Config, runErr *error) 
 		Short: apiCmdDesc,
 		Long:  apiCmdDesc,
 		Run: func(cmd *cobra.Command, args []string) {
+			go func() {
+				err := sc.StartCacheScheduler(config)
+				if err != nil {
+					return
+				}
+			}()
 			lc, err := api.NewServer(sc, *config)
 			if err != nil {
 				*runErr = err

--- a/db/dbmodel_mock.go
+++ b/db/dbmodel_mock.go
@@ -19,6 +19,8 @@ type MockPersist struct {
 	CvmTransactionsTxdata            map[string]*CvmTransactionsTxdata
 	CvmAccounts                      map[string]*CvmAccount
 	CvmBlocks                        map[string]*CvmBlocks
+	CamLastBlockCache                map[string]*CamLastBlockCache
+	CountLastBlockCache              map[string]*CountLastBlockCache
 	CvmAddresses                     map[string]*CvmAddresses
 	TransactionsValidator            map[string]*TransactionsValidator
 	TransactionsBlock                map[string]*TransactionsBlock
@@ -53,6 +55,7 @@ func NewPersistMock() *MockPersist {
 		CvmTransactionsTxdata:            make(map[string]*CvmTransactionsTxdata),
 		CvmAccounts:                      make(map[string]*CvmAccount),
 		CvmBlocks:                        make(map[string]*CvmBlocks),
+		CamLastBlockCache:                make(map[string]*CamLastBlockCache),
 		CvmAddresses:                     make(map[string]*CvmAddresses),
 		TransactionsValidator:            make(map[string]*TransactionsValidator),
 		TransactionsBlock:                make(map[string]*TransactionsBlock),
@@ -247,6 +250,38 @@ func (m *MockPersist) InsertCvmBlocks(ctx context.Context, runner dbr.SessionRun
 	nv := &CvmBlocks{}
 	*nv = *v
 	m.CvmBlocks[v.Block] = nv
+	return nil
+}
+
+// this mock needs to be enriched
+func (m *MockPersist) QueryCountLastBlockCache(ctx context.Context, runner dbr.SessionRunner, v *CamLastBlockCache) (*CountLastBlockCache, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	if _, present := m.CamLastBlockCache[v.ChainID]; present {
+		cnt := &CountLastBlockCache{
+			Cnt: 1,
+		}
+		return cnt, nil
+	}
+	return &CountLastBlockCache{}, nil
+}
+
+func (m *MockPersist) QueryCamLastBlockCache(ctx context.Context, runner dbr.SessionRunner, v *CamLastBlockCache) (*CamLastBlockCache, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if v, present := m.CamLastBlockCache[v.ChainID]; present {
+		return v, nil
+	}
+	return nil, nil
+}
+
+func (m *MockPersist) InsertCamLastBlockCache(ctx context.Context, runner dbr.SessionRunner, v *CamLastBlockCache, flag bool) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	nv := &CamLastBlockCache{}
+	*nv = *v
+	m.CamLastBlockCache[v.CurrentBlock] = nv
 	return nil
 }
 

--- a/db/dbmodel_test.go
+++ b/db/dbmodel_test.go
@@ -23,8 +23,10 @@ import (
 	"github.com/gocraft/dbr/v2"
 )
 
-const TestDB = "mysql"
-const TestDSN = "root:password@tcp(127.0.0.1:3306)/magellan_test?parseTime=true"
+const (
+	TestDB  = "mysql"
+	TestDSN = "root:password@tcp(127.0.0.1:3306)/magellan_test?parseTime=true"
+)
 
 func TestTransaction(t *testing.T) {
 	p := NewPersist()

--- a/docker/standalone/docker-compose.yml
+++ b/docker/standalone/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   camino:
     env_file:
       - standalone.env
-    image: "c4tplatform/camino-node:v0.2.0"
+    image: "c4tplatform/camino-node:v0.2.1-rc1"
     command: /bin/sh -cx "exec /camino-node/build/camino-node
       --config-file=/opt/config.json
       --network-id=$${NETWORKID}
@@ -19,14 +19,14 @@ services:
       - "9650:9650"
     volumes:
       - camino-data:/var/lib/camino
-      - ./../camino-node_config.json:/opt/config.json
-      - ./../camino-node_chain_config:/opt/camino-node
+      - ./../caminogo_config.json:/opt/config.json
+      - ./../caminogo_chain_config:/opt/camino-node
       - camino-ipcs:/tmp
     depends_on:
       - indexer
     restart: always
   indexer: &magellan-app
-    image: "c4tplatform/magellan:v0.1.0"
+    image: "c4tplatform/magellan:v0.2.5"
     command: ["stream", "indexer", "-c", "/opt/config.json"]
     networks:
       - services

--- a/models/collections.go
+++ b/models/collections.go
@@ -229,6 +229,10 @@ type Aggregates struct {
 
 type AggregatesList []Aggregates
 
+type BlockValue struct {
+	Block uint64 `json:"block"`
+}
+
 type AddressChains struct {
 	AddressChains map[string][]StringID `json:"addressChains"`
 }

--- a/services/db/migrations/048_cvm_blocks_created_at_index.down.sql
+++ b/services/db/migrations/048_cvm_blocks_created_at_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX cvm_blocks_created_at ON cvm_blocks;

--- a/services/db/migrations/048_cvm_blocks_created_at_index.up.sql
+++ b/services/db/migrations/048_cvm_blocks_created_at_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX cvm_blocks_created_at  ON cvm_blocks(created_at);

--- a/services/db/migrations/049_create_last_block_cache_schemas.down.sql
+++ b/services/db/migrations/049_create_last_block_cache_schemas.down.sql
@@ -1,0 +1,1 @@
+drop table cam_last_block_cache;

--- a/services/db/migrations/049_create_last_block_cache_schemas.up.sql
+++ b/services/db/migrations/049_create_last_block_cache_schemas.up.sql
@@ -1,0 +1,11 @@
+##
+## LastBlockCache
+##
+
+create table cam_last_block_cache
+(
+    current_block  decimal(65,0) NOT NULL,
+    chainid      varchar(50)   NOT NULL
+);
+
+

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -18,15 +18,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	corethType "github.com/chain4travel/caminoethvm/core/types"
 	"github.com/chain4travel/caminogo/ids"
+	"github.com/chain4travel/magellan/caching"
 	"github.com/chain4travel/magellan/cfg"
 	"github.com/chain4travel/magellan/db"
 	"github.com/chain4travel/magellan/models"
@@ -35,18 +34,16 @@ import (
 	"github.com/chain4travel/magellan/servicesctrl"
 	"github.com/chain4travel/magellan/utils"
 	"github.com/gocraft/dbr/v2"
+
+	corethType "github.com/chain4travel/caminoethvm/core/types"
 )
 
 const (
-	MaxAggregateIntervalCount = 20000
-
 	MinSearchQueryLength = 3
 )
 
 var (
-	ErrAggregateIntervalCountTooLarge = errors.New("requesting too many intervals")
-	ErrFailedToParseStringAsBigInt    = errors.New("failed to parse string to big.Int")
-	ErrSearchQueryTooShort            = errors.New("search query too short")
+	ErrSearchQueryTooShort = errors.New("search query too short")
 
 	outputSelectColumns = []string{
 		"avm_outputs.id",
@@ -163,461 +160,59 @@ func (r *Reader) Search(ctx context.Context, p *params.SearchParams, avaxAssetID
 	return collateSearchResults(assets, addresses, txs, cblocks, ctrans, caddr)
 }
 
-func (r *Reader) TxfeeAggregate(ctx context.Context, params *params.TxfeeAggregateParams) (*models.TxfeeAggregatesHistogram, error) {
-	// Validate params and set defaults if necessary
-	if params.ListParams.StartTime.IsZero() {
-		var err error
-		params.ListParams.StartTime, err = r.getFirstTransactionTime(ctx, params.ChainIDs)
-		if err != nil {
-			return nil, err
-		}
-	}
+func (r *Reader) TxfeeAggregate(aggregateCache caching.AggregatesCache, params *params.TxfeeAggregateParams) (*models.TxfeeAggregatesHistogram, error) {
+	// if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
+	aggregateFeesMap := aggregateCache.GetAggregateFeesMap()
+	if len(aggregateFeesMap) != 0 {
+		cache := models.TxfeeAggregatesList{}
+		temp := models.TxfeeAggregates{}
 
-	intervals := models.TxfeeAggregatesList{}
+		// based on the date interval we are going to retrieve the relevant part from our cache
+		keyDatePartValue := cfg.GetDatepartBasedOnDateParams(params.ListParams.StartTime, params.ListParams.EndTime)
+		temp.Txfee = aggregateFeesMap[params.ChainIDs[0]][keyDatePartValue]
 
-	// Ensure the interval count requested isn't too large
-	intervalSeconds := int64(params.IntervalSize.Seconds())
-	requestedIntervalCount := 0
-	if intervalSeconds != 0 {
-		requestedIntervalCount = int(math.Ceil(params.ListParams.EndTime.Sub(params.ListParams.StartTime).Seconds() / params.IntervalSize.Seconds()))
-		if requestedIntervalCount > MaxAggregateIntervalCount {
-			return nil, ErrAggregateIntervalCountTooLarge
-		}
-		if requestedIntervalCount < 1 {
-			requestedIntervalCount = 1
-		}
-	}
-
-	// Split chains
-	var avmChains, cvmChains []string
-	if len(params.ChainIDs) == 0 {
-		for id, chain := range r.sc.Chains {
-			switch chain.VMType {
-			case models.CVMName:
-				cvmChains = append(cvmChains, id)
-			default:
-				avmChains = append(avmChains, id)
-			}
-		}
-	} else {
-		for _, id := range params.ChainIDs {
-			chain, exist := r.sc.Chains[id]
-			if exist {
-				switch chain.VMType {
-				case models.CVMName:
-					cvmChains = append(cvmChains, id)
-				default:
-					avmChains = append(avmChains, id)
-				}
-			}
-		}
-	}
-
-	// Build the query and load the base data
-	dbRunner, err := r.conns.DB().NewSession("get_txfee_aggregates_histogram", cfg.RequestTimeout)
-	if err != nil {
-		return nil, err
-	}
-
-	var builder *dbr.SelectStmt
-
-	if len(avmChains) > 0 {
-		columns := []string{
-			"CAST(COALESCE(SUM(avm_transactions.txfee), 0) AS UNSIGNED) AS txfee",
-		}
-
-		if requestedIntervalCount > 0 {
-			columns = append(columns, fmt.Sprintf(
-				"FLOOR((UNIX_TIMESTAMP(avm_transactions.created_at)-%d) / %d) AS interval_id",
-				params.ListParams.StartTime.Unix(),
-				intervalSeconds))
-		}
-
-		builder = dbRunner.
-			Select(columns...).
-			From("avm_transactions").
-			Where("avm_transactions.created_at >= ?", params.ListParams.StartTime).
-			Where("avm_transactions.created_at < ?", params.ListParams.EndTime)
-
-		if requestedIntervalCount > 0 {
-			builder.
-				GroupBy("interval_id").
-				OrderAsc("interval_id").
-				Limit(uint64(requestedIntervalCount))
-		}
-
-		if len(params.ChainIDs) != 0 {
-			builder.Where("avm_transactions.chain_id IN ?", params.ChainIDs)
-		}
-
-		_, err = builder.LoadContext(ctx, &intervals)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if len(cvmChains) > 0 {
-		columns := []string{
-			"CAST(COALESCE(SUM((cvm_transactions_txdata.gas_price / 1000000000) * cvm_transactions_txdata.gas_used), 0) AS UNSIGNED) AS txfee",
-		}
-
-		if requestedIntervalCount > 0 {
-			columns = append(columns, fmt.Sprintf(
-				"FLOOR((UNIX_TIMESTAMP(cvm_transactions_txdata.created_at)-%d) / %d) AS interval_id",
-				params.ListParams.StartTime.Unix(),
-				intervalSeconds))
-		}
-
-		builder = dbRunner.
-			Select(columns...).
-			From("cvm_transactions_txdata").
-			Where("cvm_transactions_txdata.created_at >= ?", params.ListParams.StartTime).
-			Where("cvm_transactions_txdata.created_at < ?", params.ListParams.EndTime)
-
-		if requestedIntervalCount > 0 {
-			builder.
-				GroupBy("interval_id").
-				OrderAsc("interval_id").
-				Limit(uint64(requestedIntervalCount))
-		}
-
-		if len(params.ChainIDs) != 0 {
-			builder.
-				Join("cvm_blocks", "cvm_blocks.block = cvm_transactions_txdata.block").
-				Where("cvm_blocks.chain_id IN ?", cvmChains)
-		}
-
-		cvmIntervals := models.TxfeeAggregatesList{}
-
-		_, err = builder.LoadContext(ctx, &cvmIntervals)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(intervals) == 0 {
-			intervals = cvmIntervals
-		} else {
-			models.MergeAggregates(intervals.MergeList(), cvmIntervals.MergeList())
-		}
-	}
-
-	// If no intervals were requested then the total aggregate is equal to the
-	// first (and only) interval, and we're done
-	if requestedIntervalCount == 0 {
-		// This check should never fail if the SQL query is correct, but added for
-		// robustness to prevent panics if the invariant does not hold.
-		if len(intervals) > 0 {
-			intervals[0].StartTime = params.ListParams.StartTime
-			intervals[0].EndTime = params.ListParams.EndTime
-			return &models.TxfeeAggregatesHistogram{
-				TxfeeAggregates: intervals[0],
-				StartTime:       params.ListParams.StartTime,
-				EndTime:         params.ListParams.EndTime,
-			}, nil
-		}
+		cache = append(cache, temp)
+		cache[0].StartTime = params.ListParams.StartTime
+		cache[0].EndTime = params.ListParams.EndTime
 		return &models.TxfeeAggregatesHistogram{
-			StartTime: params.ListParams.StartTime,
-			EndTime:   params.ListParams.EndTime,
+			TxfeeAggregates: cache[0],
+			StartTime:       params.ListParams.StartTime,
+			EndTime:         params.ListParams.EndTime,
 		}, nil
 	}
 
-	// We need to return multiple intervals so build them now.
-	// Intervals without any data will not return anything so we pad our results
-	// with empty aggregates.
-	//
-	// We also add the start and end times of each interval to that interval
-	aggs := &models.TxfeeAggregatesHistogram{IntervalSize: params.IntervalSize}
-
-	var startTS int64
-	timesForInterval := func(intervalIdx int) (time.Time, time.Time) {
-		startTS = params.ListParams.StartTime.Unix() + (int64(intervalIdx) * intervalSeconds)
-		return time.Unix(startTS, 0).UTC(),
-			time.Unix(startTS+intervalSeconds-1, 0).UTC()
-	}
-
-	padTo := func(slice []models.TxfeeAggregates, to int) []models.TxfeeAggregates {
-		for i := len(slice); i < to; i = len(slice) {
-			slice = append(slice, models.TxfeeAggregates{IntervalID: i})
-			slice[i].StartTime, slice[i].EndTime = timesForInterval(i)
-		}
-		return slice
-	}
-
-	// Collect the overall counts and pad the intervals to include empty intervals
-	// which are not returned by the db
-	aggs.TxfeeAggregates = models.TxfeeAggregates{StartTime: params.ListParams.StartTime, EndTime: params.ListParams.EndTime}
-	var totalVolume uint64 = 0
-
-	// Add each interval, but first pad up to that interval's index
-	aggs.Intervals = make([]models.TxfeeAggregates, 0, requestedIntervalCount)
-	for _, interval := range intervals {
-		// Pad up to this interval's position
-		aggs.Intervals = padTo(aggs.Intervals, interval.IntervalID)
-
-		// Format this interval
-		interval.StartTime, interval.EndTime = timesForInterval(interval.IntervalID)
-
-		// Add to the overall aggregates counts
-		totalVolume += interval.Txfee
-
-		// Add to the list of intervals
-		aggs.Intervals = append(aggs.Intervals, interval)
-	}
-	// Add total aggregated token amounts
-	aggs.TxfeeAggregates.Txfee = totalVolume
-
-	// Add any missing trailing intervals
-	aggs.Intervals = padTo(aggs.Intervals, requestedIntervalCount)
-
-	aggs.StartTime = params.ListParams.StartTime
-	aggs.EndTime = params.ListParams.EndTime
-
-	return aggs, nil
+	return &models.TxfeeAggregatesHistogram{
+		TxfeeAggregates: models.TxfeeAggregates{},
+		StartTime:       params.ListParams.StartTime,
+		EndTime:         params.ListParams.EndTime,
+	}, nil
 }
 
-func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams, conns *utils.Connections) (*models.AggregatesHistogram, error) {
-	// Validate params and set defaults if necessary
-	if params.ListParams.StartTime.IsZero() {
-		var err error
-		params.ListParams.StartTime, err = r.getFirstTransactionTime(ctx, params.ChainIDs)
-		if err != nil {
-			return nil, err
-		}
-	}
+//gocyclo:ignore
+func (r *Reader) Aggregate(aggregateCache caching.AggregatesCache, params *params.AggregateParams) (*models.AggregatesHistogram, error) {
+	aggregateTransactionMap := aggregateCache.GetAggregateTransactionsMap()
+	if len(aggregateTransactionMap) != 0 {
+		// if the request is not coming from the caching mechanism then return the values of the cache and do NOT probe the database
+		cache := models.AggregatesList{}
+		temp := models.Aggregates{}
+		// based on the date interval we are going to retrieve the relevant part from our cache
+		keyDatePartValue := cfg.GetDatepartBasedOnDateParams(params.ListParams.StartTime, params.ListParams.EndTime)
+		temp.TransactionCount = aggregateTransactionMap[params.ChainIDs[0]][keyDatePartValue]
 
-	intervals := models.AggregatesList{}
-
-	// Ensure the interval count requested isn't too large
-	intervalSeconds := int64(params.IntervalSize.Seconds())
-	requestedIntervalCount := 0
-	if intervalSeconds != 0 {
-		requestedIntervalCount = int(math.Ceil(params.ListParams.EndTime.Sub(params.ListParams.StartTime).Seconds() / params.IntervalSize.Seconds()))
-		if requestedIntervalCount > MaxAggregateIntervalCount {
-			return nil, ErrAggregateIntervalCountTooLarge
-		}
-		if requestedIntervalCount < 1 {
-			requestedIntervalCount = 1
-		}
-	}
-
-	// Split chains
-	var avmChains, cvmChains []string
-	if len(params.ChainIDs) == 0 {
-		for id, chain := range r.sc.Chains {
-			switch chain.VMType {
-			case models.CVMName:
-				cvmChains = append(cvmChains, id)
-			default:
-				avmChains = append(avmChains, id)
-			}
-		}
-	} else {
-		for _, id := range params.ChainIDs {
-			chain, exist := r.sc.Chains[id]
-			if exist {
-				switch chain.VMType {
-				case models.CVMName:
-					cvmChains = append(cvmChains, id)
-				default:
-					avmChains = append(avmChains, id)
-				}
-			}
-		}
-	}
-
-	var dbRunner *dbr.Session
-	var err error
-
-	if conns != nil {
-		dbRunner = conns.DB().NewSessionForEventReceiver(conns.Stream().NewJob("get_transaction_aggregates_histogram"))
-	} else {
-		dbRunner, err = r.conns.DB().NewSession("get_transaction_aggregates_histogram", cfg.RequestTimeout)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	var builder *dbr.SelectStmt
-
-	if len(avmChains) > 0 {
-		columns := []string{
-			"COALESCE(SUM(avm_outputs.amount), 0) AS transaction_volume",
-			"COUNT(DISTINCT(avm_outputs.transaction_id)) AS transaction_count",
-			"COUNT(DISTINCT(avm_output_addresses.address)) AS address_count",
-			"COUNT(DISTINCT(avm_outputs.asset_id)) AS asset_count",
-			"COUNT(avm_outputs.id) AS output_count",
-		}
-
-		if requestedIntervalCount > 0 {
-			columns = append(columns, fmt.Sprintf(
-				"FLOOR((UNIX_TIMESTAMP(avm_outputs.created_at)-%d) / %d) AS interval_id",
-				params.ListParams.StartTime.Unix(),
-				intervalSeconds))
-		}
-
-		builder = dbRunner.
-			Select(columns...).
-			From("avm_outputs").
-			LeftJoin("avm_output_addresses", "avm_output_addresses.output_id = avm_outputs.id").
-			Where("avm_outputs.created_at >= ?", params.ListParams.StartTime).
-			Where("avm_outputs.created_at < ?", params.ListParams.EndTime)
-
-		if len(params.ChainIDs) != 0 {
-			builder.Where("avm_outputs.chain_id IN ?", avmChains)
-		}
-
-		if params.AssetID != nil {
-			builder.Where("avm_outputs.asset_id = ?", params.AssetID.String())
-		}
-
-		if requestedIntervalCount > 0 {
-			builder.
-				GroupBy("interval_id").
-				OrderAsc("interval_id").
-				Limit(uint64(requestedIntervalCount))
-		}
-
-		_, err = builder.LoadContext(ctx, &intervals)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if len(cvmChains) > 0 {
-		columns := []string{
-			"COALESCE(SUM(cvm_transactions_txdata.amount), 0) AS transaction_volume",
-			"COUNT(cvm_transactions_txdata.hash) AS transaction_count",
-			"COUNT(DISTINCT(cvm_transactions_txdata.id_from_addr)) AS address_count",
-			"1 AS asset_count",
-			"0 AS output_count",
-		}
-
-		if requestedIntervalCount > 0 {
-			columns = append(columns, fmt.Sprintf(
-				"FLOOR((UNIX_TIMESTAMP(cvm_transactions_txdata.created_at)-%d) / %d) AS interval_id",
-				params.ListParams.StartTime.Unix(),
-				intervalSeconds))
-		}
-
-		builder = dbRunner.
-			Select(columns...).
-			From("cvm_transactions_txdata")
-
-		if len(params.ChainIDs) != 0 {
-			builder.Join("cvm_blocks", "cvm_blocks.block = cvm_transactions_txdata.block").
-				Where("cvm_blocks.chain_id IN ?", cvmChains)
-		}
-
-		builder.Where("cvm_transactions_txdata.created_at >= ?", params.ListParams.StartTime).
-			Where("cvm_transactions_txdata.created_at < ?", params.ListParams.EndTime)
-
-		if requestedIntervalCount > 0 {
-			builder.
-				GroupBy("interval_id").
-				OrderAsc("interval_id").
-				Limit(uint64(requestedIntervalCount))
-		}
-
-		cvmIntervals := models.AggregatesList{}
-
-		_, err = builder.LoadContext(ctx, &cvmIntervals)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(intervals) == 0 {
-			intervals = cvmIntervals
-		} else {
-			models.MergeAggregates(intervals.MergeList(), cvmIntervals.MergeList())
-		}
-	}
-
-	// If no intervals were requested then the total aggregate is equal to the
-	// first (and only) interval, and we're done
-	if requestedIntervalCount == 0 {
-		// This check should never fail if the SQL query is correct, but added for
-		// robustness to prevent panics if the invariant does not hold.
-		if len(intervals) > 0 {
-			intervals[0].StartTime = params.ListParams.StartTime
-			intervals[0].EndTime = params.ListParams.EndTime
-			return &models.AggregatesHistogram{
-				Aggregates: intervals[0],
-				StartTime:  params.ListParams.StartTime,
-				EndTime:    params.ListParams.EndTime,
-			}, nil
-		}
+		cache = append(cache, temp)
+		cache[0].StartTime = params.ListParams.StartTime
+		cache[0].EndTime = params.ListParams.EndTime
 		return &models.AggregatesHistogram{
-			StartTime: params.ListParams.StartTime,
-			EndTime:   params.ListParams.EndTime,
+			Aggregates: cache[0],
+			StartTime:  params.ListParams.StartTime,
+			EndTime:    params.ListParams.EndTime,
 		}, nil
 	}
-
-	// We need to return multiple intervals so build them now.
-	// Intervals without any data will not return anything so we pad our results
-	// with empty aggregates.
-	//
-	// We also add the start and end times of each interval to that interval
-	aggs := &models.AggregatesHistogram{IntervalSize: params.IntervalSize}
-
-	var startTS int64
-	timesForInterval := func(intervalIdx int) (time.Time, time.Time) {
-		startTS = params.ListParams.StartTime.Unix() + (int64(intervalIdx) * intervalSeconds)
-		return time.Unix(startTS, 0).UTC(),
-			time.Unix(startTS+intervalSeconds-1, 0).UTC()
-	}
-
-	padTo := func(slice []models.Aggregates, to int) []models.Aggregates {
-		for i := len(slice); i < to; i = len(slice) {
-			slice = append(slice, models.Aggregates{IntervalID: i})
-			slice[i].StartTime, slice[i].EndTime = timesForInterval(i)
-		}
-		return slice
-	}
-
-	// Collect the overall counts and pad the intervals to include empty intervals
-	// which are not returned by the db
-	aggs.Aggregates = models.Aggregates{StartTime: params.ListParams.StartTime, EndTime: params.ListParams.EndTime}
-	var (
-		bigIntFromStringOK bool
-		totalVolume        = big.NewInt(0)
-		intervalVolume     = big.NewInt(0)
-	)
-
-	// Add each interval, but first pad up to that interval's index
-	aggs.Intervals = make([]models.Aggregates, 0, requestedIntervalCount)
-	for _, interval := range intervals {
-		// Pad up to this interval's position
-		aggs.Intervals = padTo(aggs.Intervals, interval.IntervalID)
-
-		// Format this interval
-		interval.StartTime, interval.EndTime = timesForInterval(interval.IntervalID)
-
-		// Parse volume into a big.Int
-		_, bigIntFromStringOK = intervalVolume.SetString(string(interval.TransactionVolume), 10)
-		if !bigIntFromStringOK {
-			return nil, ErrFailedToParseStringAsBigInt
-		}
-
-		// Add to the overall aggregates counts
-		totalVolume.Add(totalVolume, intervalVolume)
-		aggs.Aggregates.TransactionCount += interval.TransactionCount
-		aggs.Aggregates.OutputCount += interval.OutputCount
-		aggs.Aggregates.AddressCount += interval.AddressCount
-		aggs.Aggregates.AssetCount += interval.AssetCount
-
-		// Add to the list of intervals
-		aggs.Intervals = append(aggs.Intervals, interval)
-	}
-	// Add total aggregated token amounts
-	aggs.Aggregates.TransactionVolume = models.TokenAmount(totalVolume.String())
-
-	// Add any missing trailing intervals
-	aggs.Intervals = padTo(aggs.Intervals, requestedIntervalCount)
-
-	aggs.StartTime = params.ListParams.StartTime
-	aggs.EndTime = params.ListParams.EndTime
-
-	return aggs, nil
+	return &models.AggregatesHistogram{
+		Aggregates: models.Aggregates{},
+		StartTime:  params.ListParams.StartTime,
+		EndTime:    params.ListParams.EndTime,
+	}, nil
 }
 
 func (r *Reader) ListAddresses(ctx context.Context, p *params.ListAddressesParams) (*models.AddressList, error) {
@@ -919,28 +514,6 @@ func (r *Reader) AddressChains(ctx context.Context, p *params.AddressChainsParam
 	}
 
 	return &resp, nil
-}
-
-func (r *Reader) getFirstTransactionTime(ctx context.Context, chainIDs []string) (time.Time, error) {
-	dbRunner, err := r.conns.DB().NewSession("get_first_transaction_time", cfg.RequestTimeout)
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	var ts float64
-	builder := dbRunner.
-		Select("COALESCE(UNIX_TIMESTAMP(MIN(created_at)), 0)").
-		From("avm_transactions")
-
-	if len(chainIDs) > 0 {
-		builder.Where("avm_transactions.chain_id IN ?", chainIDs)
-	}
-
-	err = builder.LoadOneContext(ctx, &ts)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return time.Unix(int64(math.Floor(ts)), 0).UTC(), nil
 }
 
 func (r *Reader) searchByID(ctx context.Context, id ids.ID, avaxAssetID ids.ID) (*models.SearchResults, error) {

--- a/services/indexes/avax/reader_aggregate_processor.go
+++ b/services/indexes/avax/reader_aggregate_processor.go
@@ -451,7 +451,7 @@ func (r *Reader) aggregateProcessorAssetAggr(conns *utils.Connections) {
 			}
 			p.AssetID = &id
 			r.sc.Log.Info("aggregate %s %v-%v", id.String(), p.ListParams.StartTime.Format(time.RFC3339), p.ListParams.EndTime.Format(time.RFC3339))
-			aggr, err := r.Aggregate(ctx, p, conns)
+			aggr, err := r.Aggregate(r.sc.AggregatesCache, p)
 			if err != nil {
 				r.sc.Log.Warn("Aggregate %v", err)
 				return
@@ -525,8 +525,7 @@ func (r *Reader) aggregateProcessorAssetAggr(conns *utils.Connections) {
 	}
 }
 
-func (r *Reader) processAggregate(conns *utils.Connections, runTm time.Time, tag string, intervalSize string, deltaTime time.Duration) (*models.AggregatesHistogram, error) {
-	ctx := context.Background()
+func (r *Reader) processAggregate(runTm time.Time, tag string, intervalSize string, deltaTime time.Duration) (*models.AggregatesHistogram, error) {
 	p := &params.AggregateParams{}
 	urlv := url.Values{}
 	urlv.Add(params.KeyIntervalSize, intervalSize)
@@ -539,7 +538,7 @@ func (r *Reader) processAggregate(conns *utils.Connections, runTm time.Time, tag
 	p.ListParams.StartTime = p.ListParams.EndTime.Add(deltaTime)
 	p.ChainIDs = append(p.ChainIDs, r.sc.GenesisContainer.XChainID.String())
 	r.sc.Log.Info("aggregate %s interval %s %v->%v", tag, intervalSize, p.ListParams.StartTime.Format(time.RFC3339), p.ListParams.EndTime.Format(time.RFC3339))
-	return r.Aggregate(ctx, p, conns)
+	return r.Aggregate(r.sc.AggregatesCache, p)
 }
 
 func (r *Reader) aggregateProcessor1m(conns *utils.Connections) {
@@ -552,7 +551,7 @@ func (r *Reader) aggregateProcessor1m(conns *utils.Connections) {
 	time1m := time.Now().Truncate(time.Minute)
 
 	runAgg := func(runTm time.Time) {
-		agg, err := r.processAggregate(conns, runTm, "1m", "1s", -time.Minute)
+		agg, err := r.processAggregate(runTm, "1m", "1s", -time.Minute)
 		if err != nil {
 			r.sc.Log.Warn("Aggregate %v", err)
 			return
@@ -586,7 +585,7 @@ func (r *Reader) aggregateProcessor1h(conns *utils.Connections) {
 	time1h := time.Now().Truncate(time.Minute).Truncate(5 * time.Minute)
 
 	runAgg := func(runtm time.Time) {
-		agg, err := r.processAggregate(conns, runtm, "1h", "5m", -time.Hour)
+		agg, err := r.processAggregate(runtm, "1h", "5m", -time.Hour)
 		if err != nil {
 			r.sc.Log.Warn("Aggregate %v", err)
 			return
@@ -620,7 +619,7 @@ func (r *Reader) aggregateProcessor24h(conns *utils.Connections) {
 	time24h := time.Now().Truncate(time.Minute).Truncate(15 * time.Minute)
 
 	runAgg := func(runTm time.Time) {
-		agg, err := r.processAggregate(conns, runTm, "24h", "hour", -(24 * time.Hour))
+		agg, err := r.processAggregate(runTm, "24h", "hour", -(24 * time.Hour))
 		if err != nil {
 			r.sc.Log.Warn("Aggregate %v", err)
 			return
@@ -654,7 +653,7 @@ func (r *Reader) aggregateProcessor7d(conns *utils.Connections) {
 	time7d := time.Now().Truncate(time.Minute).Truncate(30 * time.Minute)
 
 	runAgg := func(runTm time.Time) {
-		agg, err := r.processAggregate(conns, runTm, "7d", "day", -(7 * 24 * time.Hour))
+		agg, err := r.processAggregate(runTm, "7d", "day", -(7 * 24 * time.Hour))
 		if err != nil {
 			r.sc.Log.Warn("Aggregate %v", err)
 			return
@@ -688,7 +687,7 @@ func (r *Reader) aggregateProcessor30d(conns *utils.Connections) {
 	time30d := time.Now().Truncate(time.Minute).Truncate(30 * time.Minute)
 
 	runAgg := func(runTm time.Time) {
-		agg, err := r.processAggregate(conns, runTm, "30d", "day", -(30 * 24 * time.Hour))
+		agg, err := r.processAggregate(runTm, "30d", "day", -(30 * 24 * time.Hour))
 		if err != nil {
 			r.sc.Log.Warn("Aggregate %v", err)
 			return

--- a/services/indexes/avax/reader_test.go
+++ b/services/indexes/avax/reader_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/chain4travel/caminogo/utils/logging"
+	"github.com/chain4travel/magellan/caching"
 	"github.com/chain4travel/magellan/cfg"
 	"github.com/chain4travel/magellan/db"
 	"github.com/chain4travel/magellan/models"
@@ -133,7 +134,7 @@ func TestCollectInsAndOuts(t *testing.T) {
 	}
 }
 
-func TestAggregateTxfee(t *testing.T) {
+func TestAggregates(t *testing.T) {
 	reader, closeFn := newTestIndex(t)
 	defer closeFn()
 
@@ -141,48 +142,228 @@ func TestAggregateTxfee(t *testing.T) {
 
 	persist := db.NewPersist()
 
-	sess, _ := reader.conns.DB().NewSession("test_aggregate_tx_fee", cfg.RequestTimeout)
-	_, _ = sess.DeleteFrom("avm_transactions").ExecContext(ctx)
+	sessTx, _ := reader.conns.DB().NewSession("test_aggregate_tx_fee", cfg.RequestTimeout)
+	_, _ = sessTx.DeleteFrom("avm_transactions").ExecContext(ctx)
 
-	tnow := time.Now().UTC().Truncate(1 * time.Second).Add(-1 * time.Hour)
+	sessOuts, _ := reader.conns.DB().NewSession("test_aggregate_tx", cfg.RequestTimeout)
+	_, _ = sessOuts.DeleteFrom("avm_outputs").ExecContext(ctx)
 
+	timeNow := time.Now().UTC().Truncate(1 * time.Second)
+	yesterdayDateTime := time.Now().UTC().AddDate(0, 0, -1)
+	prevWeekDateTime := time.Now().UTC().AddDate(0, 0, -7)
+	prevMonthDateTime := time.Now().UTC().AddDate(0, -1, 0)
+
+	// Add transaction and output to test last days' aggregates
 	transaction := &db.Transactions{
 		ID:        "id1",
 		ChainID:   "cid",
 		Type:      "type",
 		Txfee:     10,
-		CreatedAt: tnow,
+		CreatedAt: timeNow.Add(-1 * time.Hour),
 	}
-	_ = persist.InsertTransactions(ctx, sess, transaction, false)
+	_ = persist.InsertTransactions(ctx, sessTx, transaction, false)
+	output := &db.Outputs{
+		ID:            "id1",
+		TransactionID: "id1",
+		ChainID:       "cid",
+		CreatedAt:     timeNow.Add(-1 * time.Hour),
+	}
+	_ = persist.InsertOutputs(ctx, sessOuts, output, false)
 
+	err := reader.sc.AggregatesCache.GetAggregatesFeesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		yesterdayDateTime,
+		timeNow.Add(1*time.Hour),
+		"day")
+	if err != nil {
+		t.Error("error", err)
+	}
+	err = reader.sc.AggregatesCache.GetAggregatesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		yesterdayDateTime,
+		timeNow.Add(1*time.Hour),
+		"day")
+	if err != nil {
+		t.Error("error", err)
+	}
+
+	// Add transaction and output to test last week's aggregates
 	transaction = &db.Transactions{
 		ID:        "id2",
 		ChainID:   "cid",
 		Type:      "type",
 		Txfee:     15,
-		CreatedAt: tnow.Add(-1 * time.Hour),
+		CreatedAt: timeNow.Add(-48 * time.Hour),
 	}
-	_ = persist.InsertTransactions(ctx, sess, transaction, false)
+	_ = persist.InsertTransactions(ctx, sessTx, transaction, false)
+	output = &db.Outputs{
+		ID:            "id2",
+		TransactionID: "id2",
+		ChainID:       "cid",
+		CreatedAt:     timeNow.Add(-48 * time.Hour),
+	}
+	_ = persist.InsertOutputs(ctx, sessOuts, output, false)
 
-	starttime := tnow.Add(-2 * time.Hour)
-	endtime := tnow.Add(1 * time.Second)
-	p := params.TxfeeAggregateParams{ListParams: params.ListParams{StartTime: starttime, EndTime: endtime}}
-	agg, err := reader.TxfeeAggregate(ctx, &p)
+	err = reader.sc.AggregatesCache.GetAggregatesFeesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		prevWeekDateTime,
+		timeNow.Add(1*time.Hour),
+		"week")
 	if err != nil {
 		t.Error("error", err)
 	}
-	if agg.TxfeeAggregates.Txfee != 25 {
-		t.Error("aggregate tx invalid expected ", agg.TxfeeAggregates.Txfee)
+	err = reader.sc.AggregatesCache.GetAggregatesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		prevWeekDateTime,
+		timeNow.Add(1*time.Hour),
+		"week")
+	if err != nil {
+		t.Error("error", err)
 	}
-	if agg.StartTime != starttime || agg.EndTime != endtime {
+
+	// Add transaction and output to test last month's aggregates
+	transaction = &db.Transactions{
+		ID:        "id3",
+		ChainID:   "cid",
+		Type:      "type",
+		Txfee:     20,
+		CreatedAt: timeNow.Add(-200 * time.Hour),
+	}
+	_ = persist.InsertTransactions(ctx, sessTx, transaction, false)
+	output = &db.Outputs{
+		ID:            "id3",
+		TransactionID: "id3",
+		ChainID:       "cid",
+		CreatedAt:     timeNow.Add(-200 * time.Hour),
+	}
+	_ = persist.InsertOutputs(ctx, sessOuts, output, false)
+
+	err = reader.sc.AggregatesCache.GetAggregatesFeesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		prevMonthDateTime,
+		timeNow.Add(1*time.Hour),
+		"month")
+	if err != nil {
+		t.Error("error", err)
+	}
+	err = reader.sc.AggregatesCache.GetAggregatesAndUpdate(
+		reader.sc.Chains,
+		reader.conns,
+		"cid",
+		prevMonthDateTime,
+		timeNow.Add(1*time.Hour),
+		"month")
+	if err != nil {
+		t.Error("error", err)
+	}
+
+	// Test last month's aggregates
+	startTime := timeNow.Add(-250 * time.Hour)
+	endTime := timeNow.Add(1 * time.Hour)
+
+	feeAggregateParams := params.TxfeeAggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	aggFees, err := reader.TxfeeAggregate(reader.sc.AggregatesCache, &feeAggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if aggFees.TxfeeAggregates.Txfee != 45 {
+		t.Errorf("Expected %d tx aggregate fees", 45)
+	}
+	if aggFees.StartTime != startTime || aggFees.EndTime != endTime {
+		t.Error("aggregate tx invalid")
+	}
+	aggregateParams := params.AggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	agg, err := reader.Aggregate(reader.sc.AggregatesCache, &aggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if agg.Aggregates.TransactionCount != 3 {
+		t.Errorf("Expected %d txs", 3)
+	}
+	if agg.StartTime != startTime || agg.EndTime != endTime {
 		t.Error("aggregate tx invalid")
 	}
 
-	p = params.TxfeeAggregateParams{ListParams: params.ListParams{StartTime: tnow.Add(-50 * time.Minute), EndTime: tnow.Add(1 * time.Second)}}
-	agg, _ = reader.TxfeeAggregate(ctx, &p)
+	// Test last week's aggregate fees
+	startTime = timeNow.Add(-50 * time.Hour)
+	endTime = timeNow.Add(1 * time.Hour)
 
-	if agg.TxfeeAggregates.Txfee != 10 {
-		t.Error("aggregate tx invalid expected ", agg.TxfeeAggregates.Txfee)
+	feeAggregateParams = params.TxfeeAggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	aggFees, err = reader.TxfeeAggregate(reader.sc.AggregatesCache, &feeAggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if aggFees.TxfeeAggregates.Txfee != 25 {
+		t.Errorf("Expected %d tx aggregate fees", 25)
+	}
+	if aggFees.StartTime != startTime || aggFees.EndTime != endTime {
+		t.Error("aggregate tx invalid")
+	}
+	aggregateParams = params.AggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	agg, err = reader.Aggregate(reader.sc.AggregatesCache, &aggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if agg.Aggregates.TransactionCount != 2 {
+		t.Errorf("Expected %d txs", 2)
+	}
+	if agg.StartTime != startTime || agg.EndTime != endTime {
+		t.Error("aggregate tx invalid")
+	}
+
+	// Test last days' aggregate fees
+	startTime = timeNow.Add(-5 * time.Hour)
+	endTime = timeNow.Add(1 * time.Hour)
+
+	feeAggregateParams = params.TxfeeAggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	aggFees, err = reader.TxfeeAggregate(reader.sc.AggregatesCache, &feeAggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if aggFees.TxfeeAggregates.Txfee != 10 {
+		t.Errorf("Expected %d tx aggregate fees", 10)
+	}
+	if aggFees.StartTime != startTime || aggFees.EndTime != endTime {
+		t.Error("aggregate tx invalid")
+	}
+	aggregateParams = params.AggregateParams{
+		ListParams: params.ListParams{StartTime: startTime, EndTime: endTime},
+		ChainIDs:   []string{"cid"},
+	}
+	agg, err = reader.Aggregate(reader.sc.AggregatesCache, &aggregateParams)
+	if err != nil {
+		t.Error("error", err)
+	}
+	if agg.Aggregates.TransactionCount != 1 {
+		t.Errorf("Expected %d txs", 1)
+	}
+	if agg.StartTime != startTime || agg.EndTime != endTime {
+		t.Error("aggregate tx invalid")
 	}
 }
 
@@ -205,6 +386,8 @@ func newTestIndex(t *testing.T) (*Reader, func()) {
 	}
 
 	sc := &servicesctrl.Control{Log: logging.NoLog{}, Services: conf, Chains: chains}
+	sc.AggregatesCache = caching.NewAggregatesCache()
+	sc.AggregatesCache.InitCacheStorage(chains)
 	conns, err := sc.Database()
 	if err != nil {
 		t.Fatal("Failed to create connections:", err.Error())

--- a/services/indexes/avm/avm_test.go
+++ b/services/indexes/avm/avm_test.go
@@ -36,9 +36,7 @@ import (
 	"github.com/chain4travel/magellan/utils"
 )
 
-var (
-	testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
-)
+var testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
 
 func TestIndexBootstrap(t *testing.T) {
 	conns, writer, reader, closeFn := newTestIndex(t, testXChainID)

--- a/services/indexes/cvm/cvm_test.go
+++ b/services/indexes/cvm/cvm_test.go
@@ -32,9 +32,7 @@ import (
 	"github.com/chain4travel/magellan/utils"
 )
 
-var (
-	testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
-)
+var testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
 
 func newTestIndex(t *testing.T, networkID uint32, chainID ids.ID) (*utils.Connections, *Writer, func()) {
 	logConf := logging.DefaultConfig

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -698,9 +698,7 @@ func ForValueChainID(chainID *ids.ID, chainIDs []string) []string {
 	return chainIDs
 }
 
-//
 // Sorting
-//
 type TransactionSort uint8
 
 func toTransactionSort(s string) TransactionSort {

--- a/services/indexes/params/params.go
+++ b/services/indexes/params/params.go
@@ -89,9 +89,7 @@ func CacheKey(name string, val interface{}) string {
 	return fmt.Sprintf("%s=%v", name, val)
 }
 
-//
 // Global params
-//
 type ListParams struct {
 	Values url.Values
 	ID     *ids.ID

--- a/services/indexes/pvm/pvm_test.go
+++ b/services/indexes/pvm/pvm_test.go
@@ -28,9 +28,7 @@ import (
 	"github.com/chain4travel/magellan/utils"
 )
 
-var (
-	testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
-)
+var testXChainID = ids.ID([32]byte{7, 193, 50, 215, 59, 55, 159, 112, 106, 206, 236, 110, 229, 14, 139, 125, 14, 101, 138, 65, 208, 44, 163, 38, 115, 182, 177, 179, 244, 34, 195, 120})
 
 func TestBootstrap(t *testing.T) {
 	conns, w, r, closeFn := newTestIndex(t, 12345, ChainID)


### PR DESCRIPTION
## Description ##

In block explorer, the calculation of the `Number of Transactions` and the `Total Gas Fees` aggregated numbers was being done on the fly by calling the corresponding endpoints. These endpoints were fetching data on a specific time window from the database by multiple queries. Thus, when this time range was big enough (month) to include more than the accepted number of transaction data, the requests were returning time out responses. 

## Solution ##

With this PR, on magellan startup, a scheduler is being started and updates the cache with these aggregated numbers on a specified interval. The cache stores these numbers for specific time windows, as requested from the block explorer. (past day, past week, past month). So, the endpoint always returns the aggregated numbers in O(1) time, by reading them from cache. 

For configuring the scheduler's interval, a new field (`cacheUpdateInterval`) is added on the `config.json` file passed as argument when running `magellan api` command. Config example:

```
{
  "networkID": 12345,
  "logDirectory": "/var/log/magellan",
  "metricsListenAddr": "",
  "listenAddr": ":8080",
  "cacheUpdateInterval": "10",
  "features": [
  ],
  "caminoNode": "http://localhost:9650",
  "nodeInstance": "default",
  "chains": {
    "2CA6j5zYzasynPsFeNoqWkmTCt3VScMvXUZHbfDJ8k3oGzAPtU": {
      "id": "2CA6j5zYzasynPsFeNoqWkmTCt3VScMvXUZHbfDJ8k3oGzAPtU",
      "vmType": "cvm"
    },
    "11111111111111111111111111111111LpoYY": {
      "id": "11111111111111111111111111111111LpoYY",
      "vmType": "pvm"
    },
    "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed": {
      "id": "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed",
      "vmType": "avm"
    }
  },
  "services": {
    "db": {
      "dsn": "root:password@tcp(mysql:3306)/magellan",
      "driver": "mysql"
    }
  }
}
```
## Changes ##

- Added cache implementation
- Added cache scheduler implementation
- Updated magellan configuration to include cache scheduler's interval 
- Updated the `TxfeeAggregate` and `Aggregate` endpoints
- Updated docker image versions
- Linting fixes
- Testing fixes

## Additional Changes ##
- Optimisation of the way data are retrieved from the db via the scheduler
- Applied separate DB timeout during Aggregate and TxFeeAggregate calculations (only used from the caching mechanism)
- Updated db indexes/scripts
- Added a cam_last_block_cache in the db that will be working as a cache of the last block inserted per chain. Update of this is done via the Magellan Indexer and more specific in the writer.go file when the indexBlockInternal method is triggered.

## Co-Authors
@kostaschri