### PR TITLE
[TECH 425] GeoIP Validators Info Service

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -71,6 +71,20 @@ func ParseGetJSON(r *web.Request, n int64) (url.Values, error) {
 	return r.URL.Query(), nil
 }
 
+func ParseGetBodyJSON(r *web.Request) (map[string]interface{}, error) {
+
+	var data map[string]interface{}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return data, err
+	}
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return data, err
+	}
+	return data, nil
+}
+
 func mergeValues(a url.Values, b url.Values) url.Values {
 	for k, v := range b {
 		if _, present := a[k]; present {

--- a/api/utils.go
+++ b/api/utils.go
@@ -72,7 +72,6 @@ func ParseGetJSON(r *web.Request, n int64) (url.Values, error) {
 }
 
 func ParseGetBodyJSON(r *web.Request) (map[string]interface{}, error) {
-
 	var data map[string]interface{}
 	body, err := io.ReadAll(r.Body)
 	if err != nil {

--- a/api/v2.go
+++ b/api/v2.go
@@ -162,7 +162,7 @@ func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams("geoIPValidatorsInfo", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetValidatorsGeoIPInfo(p.RPC, c.sc.Services.GeoIP), nil
+			return utils.GetValidatorsGeoIPInfo(p.RPC, &c.sc.Services.GeoIP)
 		},
 	})
 }

--- a/api/v2.go
+++ b/api/v2.go
@@ -165,7 +165,7 @@ func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams("geoIPValidatorsInfo", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetValidatorsGeoIPInfo(p.RPC, c.sc.Services.GeoIP), nil
+			return utils.GetValidatorsGeoIPInfo(p.RPC, &c.sc.Services.GeoIP)
 		},
 	})
 }

--- a/api/v2.go
+++ b/api/v2.go
@@ -145,7 +145,6 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 
 // AVAX
 func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
-	//body test
 	collectors := utils.NewCollectors(
 		utils.NewCounterObserveMillisCollect(MetricMillis),
 		utils.NewCounterIncCollect(MetricCount),
@@ -166,7 +165,7 @@ func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams("geoIPValidatorsInfo", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetValidatorsGeoIPInfo(p.Rpc, c.sc.Services.GeoIP), nil
+			return utils.GetValidatorsGeoIPInfo(p.RPC, c.sc.Services.GeoIP), nil
 		},
 	})
 }

--- a/api/v2.go
+++ b/api/v2.go
@@ -142,7 +142,6 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 
 // AVAX
 func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
-	//body test
 	collectors := utils.NewCollectors(
 		utils.NewCounterObserveMillisCollect(MetricMillis),
 		utils.NewCounterIncCollect(MetricCount),
@@ -163,7 +162,7 @@ func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams("geoIPValidatorsInfo", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetValidatorsGeoIPInfo(p.Rpc, c.sc.Services.GeoIP), nil
+			return utils.GetValidatorsGeoIPInfo(p.RPC, c.sc.Services.GeoIP), nil
 		},
 	})
 }

--- a/api/v2.go
+++ b/api/v2.go
@@ -118,6 +118,7 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 		Get("/transactions/aggregates", (*V2Context).Aggregate).
 		Get("/addressChains", (*V2Context).AddressChains).
 		Post("/addressChains", (*V2Context).AddressChainsPost).
+		Post("/validatorsInfo", (*V2Context).ValidatorsInfo).
 
 		// List and Get routes
 		Get("/transactions", (*V2Context).ListTransactions).
@@ -142,9 +143,33 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 		Get("/multisigalias/:owner", (*V2Context).GetMultisigAlias)
 }
 
-//
 // AVAX
-//
+func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
+	//body test
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricSearchMillis),
+		utils.NewCounterIncCollect(MetricSearchCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.ValidatorParams{}
+	if err := p.SetParamInfo(c.version, c.sc.ServicesCfg.CaminoNode); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 24 * time.Hour,
+		Key: c.cacheKeyForParams("geoIPValidatorsInfo", p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return utils.GetValidatorsGeoIPInfo(p.Rpc, c.sc.Services.GeoIP), nil
+		},
+	})
+}
 
 func (c *V2Context) Search(w web.ResponseWriter, r *web.Request) {
 	collectors := utils.NewCollectors(

--- a/api/v2.go
+++ b/api/v2.go
@@ -116,6 +116,7 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 		Get("/transactions/aggregates", (*V2Context).Aggregate).
 		Get("/addressChains", (*V2Context).AddressChains).
 		Post("/addressChains", (*V2Context).AddressChainsPost).
+		Post("/validatorsInfo", (*V2Context).ValidatorsInfo).
 
 		// List and Get routes
 		Get("/transactions", (*V2Context).ListTransactions).
@@ -139,9 +140,33 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 		Get("/cacheaggregates/:id", (*V2Context).CacheAggregates)
 }
 
-//
 // AVAX
-//
+func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
+	//body test
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricSearchMillis),
+		utils.NewCounterIncCollect(MetricSearchCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.ValidatorParams{}
+	if err := p.SetParamInfo(c.version, c.sc.ServicesCfg.CaminoNode); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 24 * time.Hour,
+		Key: c.cacheKeyForParams("geoIPValidatorsInfo", p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return utils.GetValidatorsGeoIPInfo(p.Rpc, c.sc.Services.GeoIP), nil
+		},
+	})
+}
 
 func (c *V2Context) Search(w web.ResponseWriter, r *web.Request) {
 	collectors := utils.NewCollectors(

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -94,7 +94,7 @@ type Services struct {
 }
 
 type EndpointService struct {
-	UrlEndpoint       string `json:"urlEndpoint"`
+	URLEndpoint       string `json:"urlEndpoint"`
 	AutorizationToken string `json:"autorizationToken"`
 }
 
@@ -254,7 +254,7 @@ func NewFromFile(filePath string) (*Config, error) {
 				RODSN:  dbrodsn,
 			},
 			GeoIP: EndpointService{
-				UrlEndpoint:       urlEndpointGeoIP,
+				URLEndpoint:       urlEndpointGeoIP,
 				AutorizationToken: tokenGeoIP,
 			},
 		},

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -125,7 +125,7 @@ func NewFromFile(filePath string) (*Config, error) {
 	// Get sub vipers for all objects with parents
 	servicesViper := newSubViper(v, keysServices)
 	servicesDBViper := newSubViper(servicesViper, keysServicesDB)
-	servicesGeoIPViper := newSubViper(servicesViper, keyServicesToken)
+	servicesGeoIPViper := newSubViper(servicesViper, keyServicesGeoIP)
 
 	// Get chains config
 	chains, err := newChainsConfig(v)
@@ -147,7 +147,7 @@ func NewFromFile(filePath string) (*Config, error) {
 	}
 
 	urlEndpointGeoIP := servicesGeoIPViper.GetString(keyServicesEndpoint)
-	tokenGeoIP := os.Getenv(fmt.Sprintf("%sGeoIP", keyServicesGeoIP))
+	tokenGeoIP := os.Getenv(fmt.Sprintf("%sGeoIP", keyServicesToken))
 
 	features := v.GetStringSlice(keysFeatures)
 	featuresMap := make(map[string]struct{})

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -16,7 +16,6 @@ package cfg
 import (
 	"errors"
 	"strings"
-	"time"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/version"
@@ -111,80 +110,6 @@ type DB struct {
 type Filter struct {
 	Min uint32 `json:"min"`
 	Max uint32 `json:"max"`
-}
-type IPAPIResponse struct {
-	Country     string  `json:"country"`
-	CountryCode string  `json:"countryCode"`
-	City        string  `json:"city"`
-	Lat         float64 `json:"lat"`
-	Lon         float64 `json:"lon"`
-}
-
-type ValidatorsResponse struct {
-	Jsonrpc string `json:"jsonrpc"`
-	Result  struct {
-		Validators []ValidatorInfo `json:"validators"`
-	} `json:"result"`
-}
-
-type ValidatorInfo struct {
-	TxID        string `json:"txID"`
-	StartTime   string `json:"startTime"`
-	EndTime     string `json:"endTime"`
-	StakeAmount string `json:"stakeAmount"`
-	NodeID      string `json:"nodeID"`
-	RewardOwner struct {
-		Locktime  string   `json:"locktime"`
-		Threshold string   `json:"threshold"`
-		Addresses []string `json:"addresses"`
-	} `json:"rewardOwner"`
-	PotentialReward string      `json:"potentialReward"`
-	DelegationFee   string      `json:"delegationFee"`
-	Uptime          string      `json:"uptime"`
-	Connected       bool        `json:"connected"`
-	Delegators      interface{} `json:"delegators"`
-}
-
-type PeersResponse struct {
-	Jsonrpc string `json:"jsonrpc"`
-	Result  struct {
-		NumPeers string     `json:"numPeers"`
-		Peers    []PeerInfo `json:"peers"`
-	} `json:"result"`
-	ID int `json:"id"`
-}
-
-type PeerInfo struct {
-	IP             string        `json:"ip"`
-	PublicIP       string        `json:"publicIP"`
-	NodeID         string        `json:"nodeID"`
-	Version        string        `json:"version"`
-	LastSent       time.Time     `json:"lastSent"`
-	LastReceived   time.Time     `json:"lastReceived"`
-	ObservedUptime string        `json:"observedUptime"`
-	TrackedSubnets []string      `json:"trackedSubnets"`
-	Benched        []interface{} `json:"benched"`
-}
-
-type GeoIPValidators struct {
-	Name  string      `json:"name"`
-	Value []Validator `json:"value"`
-}
-
-type Validator struct {
-	NodeID     string  `json:"nodeID"`
-	IP         string  `json:"IP"`
-	TxID       string  `json:"txID"`
-	Connected  bool    `json:"connected"`
-	StartTime  string  `json:"startTime"`
-	EndTime    string  `json:"endTime"`
-	Duration   string  `json:"duration"`
-	Uptime     string  `json:"uptime"`
-	Country    string  `json:"country"`
-	Lng        float64 `json:"lng"`
-	Lat        float64 `json:"lat"`
-	CountryISO string  `json:"countryISO"`
-	City       string  `json:"city"`
 }
 
 // NewFromFile creates a new *Config with the defaults replaced by the config  in

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -16,6 +16,7 @@ package cfg
 import (
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/version"
@@ -85,9 +86,16 @@ type Chain struct {
 type Chains map[string]Chain
 
 type Services struct {
-	Logging logging.Config `json:"logging"`
-	API     `json:"api"`
-	*DB     `json:"db"`
+	Logging           logging.Config `json:"logging"`
+	API               `json:"api"`
+	*DB               `json:"db"`
+	InmutableInsights EndpointService `json:"inmutableInsights"`
+	GeoIP             EndpointService `json:"geoIP"`
+}
+
+type EndpointService struct {
+	UrlEndpoint       string `json:"urlEndpoint"`
+	AutorizationToken string `json:"autorizationToken"`
 }
 
 type API struct {
@@ -104,6 +112,80 @@ type Filter struct {
 	Min uint32 `json:"min"`
 	Max uint32 `json:"max"`
 }
+type IPAPIResponse struct {
+	Country     string  `json:"country"`
+	CountryCode string  `json:"countryCode"`
+	City        string  `json:"city"`
+	Lat         float64 `json:"lat"`
+	Lon         float64 `json:"lon"`
+}
+
+type ValidatorsResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  struct {
+		Validators []ValidatorInfo `json:"validators"`
+	} `json:"result"`
+}
+
+type ValidatorInfo struct {
+	TxID        string `json:"txID"`
+	StartTime   string `json:"startTime"`
+	EndTime     string `json:"endTime"`
+	StakeAmount string `json:"stakeAmount"`
+	NodeID      string `json:"nodeID"`
+	RewardOwner struct {
+		Locktime  string   `json:"locktime"`
+		Threshold string   `json:"threshold"`
+		Addresses []string `json:"addresses"`
+	} `json:"rewardOwner"`
+	PotentialReward string      `json:"potentialReward"`
+	DelegationFee   string      `json:"delegationFee"`
+	Uptime          string      `json:"uptime"`
+	Connected       bool        `json:"connected"`
+	Delegators      interface{} `json:"delegators"`
+}
+
+type PeersResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  struct {
+		NumPeers string     `json:"numPeers"`
+		Peers    []PeerInfo `json:"peers"`
+	} `json:"result"`
+	ID int `json:"id"`
+}
+
+type PeerInfo struct {
+	IP             string        `json:"ip"`
+	PublicIP       string        `json:"publicIP"`
+	NodeID         string        `json:"nodeID"`
+	Version        string        `json:"version"`
+	LastSent       time.Time     `json:"lastSent"`
+	LastReceived   time.Time     `json:"lastReceived"`
+	ObservedUptime string        `json:"observedUptime"`
+	TrackedSubnets []string      `json:"trackedSubnets"`
+	Benched        []interface{} `json:"benched"`
+}
+
+type GeoIPValidators struct {
+	Name  string      `json:"name"`
+	Value []Validator `json:"value"`
+}
+
+type Validator struct {
+	NodeID     string  `json:"nodeID"`
+	IP         string  `json:"IP"`
+	TxID       string  `json:"txID"`
+	Connected  bool    `json:"connected"`
+	StartTime  string  `json:"startTime"`
+	EndTime    string  `json:"endTime"`
+	Duration   string  `json:"duration"`
+	Uptime     string  `json:"uptime"`
+	Country    string  `json:"country"`
+	Lng        float64 `json:"lng"`
+	Lat        float64 `json:"lat"`
+	CountryISO string  `json:"countryISO"`
+	City       string  `json:"city"`
+}
 
 // NewFromFile creates a new *Config with the defaults replaced by the config  in
 // the file at the given path
@@ -116,6 +198,7 @@ func NewFromFile(filePath string) (*Config, error) {
 	// Get sub vipers for all objects with parents
 	servicesViper := newSubViper(v, keysServices)
 	servicesDBViper := newSubViper(servicesViper, keysServicesDB)
+	servicesGeoIPViper := newSubViper(servicesViper, keyServicesGeoIP)
 
 	// Get chains config
 	chains, err := newChainsConfig(v)
@@ -135,6 +218,9 @@ func NewFromFile(filePath string) (*Config, error) {
 	if servicesDBViper.Get(keysServicesDBRODSN) != nil {
 		dbrodsn = servicesDBViper.GetString(keysServicesDBRODSN)
 	}
+
+	urlEndpointGeoIP := servicesGeoIPViper.GetString(keyServicesEndpoint)
+	tokenGeoIP := servicesGeoIPViper.GetString(keyServicesToken)
 
 	features := v.GetStringSlice(keysFeatures)
 	featuresMap := make(map[string]struct{})
@@ -166,6 +252,10 @@ func NewFromFile(filePath string) (*Config, error) {
 				Driver: servicesDBViper.GetString(keysServicesDBDriver),
 				DSN:    dbdsn,
 				RODSN:  dbrodsn,
+			},
+			GeoIP: EndpointService{
+				UrlEndpoint:       urlEndpointGeoIP,
+				AutorizationToken: tokenGeoIP,
 			},
 		},
 		CchainID:            v.GetString(keysStreamProducerCchainID),

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -15,6 +15,8 @@ package cfg
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -93,8 +95,8 @@ type Services struct {
 }
 
 type EndpointService struct {
-	URLEndpoint       string `json:"urlEndpoint"`
-	AutorizationToken string `json:"autorizationToken"`
+	URLEndpoint        string `json:"urlEndpoint"`
+	AuthorizationToken string `json:"authorizationToken"`
 }
 
 type API struct {
@@ -123,7 +125,7 @@ func NewFromFile(filePath string) (*Config, error) {
 	// Get sub vipers for all objects with parents
 	servicesViper := newSubViper(v, keysServices)
 	servicesDBViper := newSubViper(servicesViper, keysServicesDB)
-	servicesGeoIPViper := newSubViper(servicesViper, keyServicesGeoIP)
+	servicesGeoIPViper := newSubViper(servicesViper, keyServicesToken)
 
 	// Get chains config
 	chains, err := newChainsConfig(v)
@@ -145,7 +147,7 @@ func NewFromFile(filePath string) (*Config, error) {
 	}
 
 	urlEndpointGeoIP := servicesGeoIPViper.GetString(keyServicesEndpoint)
-	tokenGeoIP := servicesGeoIPViper.GetString(keyServicesToken)
+	tokenGeoIP := os.Getenv(fmt.Sprintf("%sGeoIP", keyServicesGeoIP))
 
 	features := v.GetStringSlice(keysFeatures)
 	featuresMap := make(map[string]struct{})
@@ -179,8 +181,8 @@ func NewFromFile(filePath string) (*Config, error) {
 				RODSN:  dbrodsn,
 			},
 			GeoIP: EndpointService{
-				URLEndpoint:       urlEndpointGeoIP,
-				AutorizationToken: tokenGeoIP,
+				URLEndpoint:        urlEndpointGeoIP,
+				AuthorizationToken: tokenGeoIP,
 			},
 		},
 		CchainID:            v.GetString(keysStreamProducerCchainID),

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -33,10 +33,9 @@ const (
 	keysServicesDBDSN    = "dsn"
 	keysServicesDBRODSN  = "ro_dsn"
 
-	keyServicesInmutable = "inmutableInsights"
-	keyServicesGeoIP     = "geoIP"
-	keyServicesEndpoint  = "urlEndpoint"
-	keyServicesToken     = "autorizationToken"
+	keyServicesGeoIP    = "geoIP"
+	keyServicesEndpoint = "urlEndpoint"
+	keyServicesToken    = "autorizationToken"
 
 	keysStreamProducerCaminoNode   = "caminoNode"
 	keysStreamProducerNodeInstance = "nodeInstance"

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -35,7 +35,7 @@ const (
 
 	keyServicesGeoIP    = "geoIP"
 	keyServicesEndpoint = "urlEndpoint"
-	keyServicesToken    = "autorizationToken"
+	keyServicesToken    = "authorizationToken"
 
 	keysStreamProducerCaminoNode   = "caminoNode"
 	keysStreamProducerNodeInstance = "nodeInstance"

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -33,6 +33,11 @@ const (
 	keysServicesDBDSN    = "dsn"
 	keysServicesDBRODSN  = "ro_dsn"
 
+	keyServicesInmutable = "inmutableInsights"
+	keyServicesGeoIP     = "geoIP"
+	keyServicesEndpoint  = "urlEndpoint"
+	keyServicesToken     = "autorizationToken"
+
 	keysStreamProducerCaminoNode   = "caminoNode"
 	keysStreamProducerNodeInstance = "nodeInstance"
 

--- a/docker/columbus/config.json
+++ b/docker/columbus/config.json
@@ -28,7 +28,7 @@
     },
     "geoIP": {
       "urlEndpoint":"http://ip-api.com/json/",
-      "autorizationToken": ""
+      "authorizationToken": ""
     }
   }
 }

--- a/docker/columbus/config.json
+++ b/docker/columbus/config.json
@@ -25,6 +25,10 @@
     "db": {
       "dsn": "root:password@tcp(mysql:3306)/magellan_columbus",
       "driver": "mysql"
+    },
+    "geoIP": {
+      "urlEndpoint":"http://ip-api.com/json/",
+      "autorizationToken": ""
     }
   }
 }

--- a/docker/config.json
+++ b/docker/config.json
@@ -24,6 +24,10 @@
     "db": {
       "dsn": "root:password@tcp(mysql:3306)/magellan",
       "driver": "mysql"
+    },
+    "geoIP": {
+      "urlEndpoint":"http://ip-api.com/json/",
+      "autorizationToken": ""
     }
   }
 }

--- a/docker/config.json
+++ b/docker/config.json
@@ -27,7 +27,7 @@
     },
     "geoIP": {
       "urlEndpoint":"http://ip-api.com/json/",
-      "autorizationToken": ""
+      "authorizationToken": ""
     }
   }
 }

--- a/docker/standalone/config.standalone.json
+++ b/docker/standalone/config.standalone.json
@@ -24,6 +24,10 @@
     "db": {
       "dsn": "root:password@tcp(mysql:3306)/magellan",
       "driver": "mysql"
+    },
+    "geoIP": {
+      "urlEndpoint":"http://ip-api.com/json/",
+      "autorizationToken": ""
     }
   }
 }

--- a/docker/standalone/config.standalone.json
+++ b/docker/standalone/config.standalone.json
@@ -27,7 +27,7 @@
     },
     "geoIP": {
       "urlEndpoint":"http://ip-api.com/json/",
-      "autorizationToken": ""
+      "authorizationToken": ""
     }
   }
 }

--- a/models/collections.go
+++ b/models/collections.go
@@ -260,19 +260,19 @@ type GeoIPValidators struct {
 }
 
 type Validator struct {
-	NodeID     ids.NodeID  `json:"nodeID"`
-	IP         string  `json:"IP"`
-	TxID       ids.ID  `json:"txID"`
-	Connected  bool    `json:"connected"`
-	StartTime  string  `json:"startTime"`
-	EndTime    string  `json:"endTime"`
-	Duration   string  `json:"duration"`
-	Uptime     float32  `json:"uptime"`
-	Country    string  `json:"country"`
-	Lng        float64 `json:"lng"`
-	Lat        float64 `json:"lat"`
-	CountryISO string  `json:"countryISO"`
-	City       string  `json:"city"`
+	NodeID     ids.NodeID `json:"nodeID"`
+	TxID       ids.ID     `json:"txID"`
+	Connected  bool       `json:"connected"`
+	Uptime     float32    `json:"uptime"`
+	Lng        float64    `json:"lng"`
+	Lat        float64    `json:"lat"`
+	IP         string     `json:"IP"`
+	StartTime  string     `json:"startTime"`
+	EndTime    string     `json:"endTime"`
+	Duration   string     `json:"duration"`
+	Country    string     `json:"country"`
+	CountryISO string     `json:"countryISO"`
+	City       string     `json:"city"`
 }
 
 /*******************  Merging  ***********************/

--- a/models/collections.go
+++ b/models/collections.go
@@ -297,8 +297,8 @@ type PeerInfo struct {
 }
 
 type GeoIPValidators struct {
-	Name  string      `json:"name"`
-	Value []Validator `json:"value"`
+	Name  string       `json:"name"`
+	Value []*Validator `json:"value"`
 }
 
 type Validator struct {

--- a/models/collections.go
+++ b/models/collections.go
@@ -254,66 +254,20 @@ type IPAPIResponse struct {
 	Lon         float64 `json:"lon"`
 }
 
-type ValidatorsResponse struct {
-	Jsonrpc string `json:"jsonrpc"`
-	Result  struct {
-		Validators []ValidatorInfo `json:"validators"`
-	} `json:"result"`
-}
-
-type ValidatorInfo struct {
-	TxID        string `json:"txID"`
-	StartTime   string `json:"startTime"`
-	EndTime     string `json:"endTime"`
-	StakeAmount string `json:"stakeAmount"`
-	NodeID      string `json:"nodeID"`
-	RewardOwner struct {
-		Locktime  string   `json:"locktime"`
-		Threshold string   `json:"threshold"`
-		Addresses []string `json:"addresses"`
-	} `json:"rewardOwner"`
-	PotentialReward string      `json:"potentialReward"`
-	DelegationFee   string      `json:"delegationFee"`
-	Uptime          string      `json:"uptime"`
-	Connected       bool        `json:"connected"`
-	Delegators      interface{} `json:"delegators"`
-}
-
-type PeersResponse struct {
-	Jsonrpc string `json:"jsonrpc"`
-	Result  struct {
-		NumPeers string     `json:"numPeers"`
-		Peers    []PeerInfo `json:"peers"`
-	} `json:"result"`
-	ID int `json:"id"`
-}
-
-type PeerInfo struct {
-	IP             string        `json:"ip"`
-	PublicIP       string        `json:"publicIP"`
-	NodeID         string        `json:"nodeID"`
-	Version        string        `json:"version"`
-	LastSent       time.Time     `json:"lastSent"`
-	LastReceived   time.Time     `json:"lastReceived"`
-	ObservedUptime string        `json:"observedUptime"`
-	TrackedSubnets []string      `json:"trackedSubnets"`
-	Benched        []interface{} `json:"benched"`
-}
-
 type GeoIPValidators struct {
 	Name  string       `json:"name"`
 	Value []*Validator `json:"value"`
 }
 
 type Validator struct {
-	NodeID     string  `json:"nodeID"`
+	NodeID     ids.NodeID  `json:"nodeID"`
 	IP         string  `json:"IP"`
-	TxID       string  `json:"txID"`
+	TxID       ids.ID  `json:"txID"`
 	Connected  bool    `json:"connected"`
 	StartTime  string  `json:"startTime"`
 	EndTime    string  `json:"endTime"`
 	Duration   string  `json:"duration"`
-	Uptime     string  `json:"uptime"`
+	Uptime     float32  `json:"uptime"`
 	Country    string  `json:"country"`
 	Lng        float64 `json:"lng"`
 	Lat        float64 `json:"lat"`

--- a/models/collections.go
+++ b/models/collections.go
@@ -246,6 +246,81 @@ type AssetAggregate struct {
 	Aggregate *AggregatesHistogram `json:"aggregate"`
 }
 
+type IPAPIResponse struct {
+	Country     string  `json:"country"`
+	CountryCode string  `json:"countryCode"`
+	City        string  `json:"city"`
+	Lat         float64 `json:"lat"`
+	Lon         float64 `json:"lon"`
+}
+
+type ValidatorsResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  struct {
+		Validators []ValidatorInfo `json:"validators"`
+	} `json:"result"`
+}
+
+type ValidatorInfo struct {
+	TxID        string `json:"txID"`
+	StartTime   string `json:"startTime"`
+	EndTime     string `json:"endTime"`
+	StakeAmount string `json:"stakeAmount"`
+	NodeID      string `json:"nodeID"`
+	RewardOwner struct {
+		Locktime  string   `json:"locktime"`
+		Threshold string   `json:"threshold"`
+		Addresses []string `json:"addresses"`
+	} `json:"rewardOwner"`
+	PotentialReward string      `json:"potentialReward"`
+	DelegationFee   string      `json:"delegationFee"`
+	Uptime          string      `json:"uptime"`
+	Connected       bool        `json:"connected"`
+	Delegators      interface{} `json:"delegators"`
+}
+
+type PeersResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  struct {
+		NumPeers string     `json:"numPeers"`
+		Peers    []PeerInfo `json:"peers"`
+	} `json:"result"`
+	ID int `json:"id"`
+}
+
+type PeerInfo struct {
+	IP             string        `json:"ip"`
+	PublicIP       string        `json:"publicIP"`
+	NodeID         string        `json:"nodeID"`
+	Version        string        `json:"version"`
+	LastSent       time.Time     `json:"lastSent"`
+	LastReceived   time.Time     `json:"lastReceived"`
+	ObservedUptime string        `json:"observedUptime"`
+	TrackedSubnets []string      `json:"trackedSubnets"`
+	Benched        []interface{} `json:"benched"`
+}
+
+type GeoIPValidators struct {
+	Name  string      `json:"name"`
+	Value []Validator `json:"value"`
+}
+
+type Validator struct {
+	NodeID     string  `json:"nodeID"`
+	IP         string  `json:"IP"`
+	TxID       string  `json:"txID"`
+	Connected  bool    `json:"connected"`
+	StartTime  string  `json:"startTime"`
+	EndTime    string  `json:"endTime"`
+	Duration   string  `json:"duration"`
+	Uptime     string  `json:"uptime"`
+	Country    string  `json:"country"`
+	Lng        float64 `json:"lng"`
+	Lat        float64 `json:"lat"`
+	CountryISO string  `json:"countryISO"`
+	City       string  `json:"city"`
+}
+
 /*******************  Merging  ***********************/
 
 type AggregateMerge interface {

--- a/models/collections.go
+++ b/models/collections.go
@@ -242,6 +242,81 @@ type AssetAggregate struct {
 	Aggregate *AggregatesHistogram `json:"aggregate"`
 }
 
+type IPAPIResponse struct {
+	Country     string  `json:"country"`
+	CountryCode string  `json:"countryCode"`
+	City        string  `json:"city"`
+	Lat         float64 `json:"lat"`
+	Lon         float64 `json:"lon"`
+}
+
+type ValidatorsResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  struct {
+		Validators []ValidatorInfo `json:"validators"`
+	} `json:"result"`
+}
+
+type ValidatorInfo struct {
+	TxID        string `json:"txID"`
+	StartTime   string `json:"startTime"`
+	EndTime     string `json:"endTime"`
+	StakeAmount string `json:"stakeAmount"`
+	NodeID      string `json:"nodeID"`
+	RewardOwner struct {
+		Locktime  string   `json:"locktime"`
+		Threshold string   `json:"threshold"`
+		Addresses []string `json:"addresses"`
+	} `json:"rewardOwner"`
+	PotentialReward string      `json:"potentialReward"`
+	DelegationFee   string      `json:"delegationFee"`
+	Uptime          string      `json:"uptime"`
+	Connected       bool        `json:"connected"`
+	Delegators      interface{} `json:"delegators"`
+}
+
+type PeersResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  struct {
+		NumPeers string     `json:"numPeers"`
+		Peers    []PeerInfo `json:"peers"`
+	} `json:"result"`
+	ID int `json:"id"`
+}
+
+type PeerInfo struct {
+	IP             string        `json:"ip"`
+	PublicIP       string        `json:"publicIP"`
+	NodeID         string        `json:"nodeID"`
+	Version        string        `json:"version"`
+	LastSent       time.Time     `json:"lastSent"`
+	LastReceived   time.Time     `json:"lastReceived"`
+	ObservedUptime string        `json:"observedUptime"`
+	TrackedSubnets []string      `json:"trackedSubnets"`
+	Benched        []interface{} `json:"benched"`
+}
+
+type GeoIPValidators struct {
+	Name  string      `json:"name"`
+	Value []Validator `json:"value"`
+}
+
+type Validator struct {
+	NodeID     string  `json:"nodeID"`
+	IP         string  `json:"IP"`
+	TxID       string  `json:"txID"`
+	Connected  bool    `json:"connected"`
+	StartTime  string  `json:"startTime"`
+	EndTime    string  `json:"endTime"`
+	Duration   string  `json:"duration"`
+	Uptime     string  `json:"uptime"`
+	Country    string  `json:"country"`
+	Lng        float64 `json:"lng"`
+	Lat        float64 `json:"lat"`
+	CountryISO string  `json:"countryISO"`
+	City       string  `json:"city"`
+}
+
 /*******************  Merging  ***********************/
 
 type AggregateMerge interface {

--- a/models/collections.go
+++ b/models/collections.go
@@ -301,8 +301,8 @@ type PeerInfo struct {
 }
 
 type GeoIPValidators struct {
-	Name  string      `json:"name"`
-	Value []Validator `json:"value"`
+	Name  string       `json:"name"`
+	Value []*Validator `json:"value"`
 }
 
 type Validator struct {

--- a/models/platform.go
+++ b/models/platform.go
@@ -30,3 +30,19 @@ type BlockList struct {
 	ListMetadata
 	Blocks []*Block `json:"blocks"`
 }
+
+type BodyRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params"`
+	ID      int         `json:"id"`
+}
+
+type CurrentValidatorsParams struct {
+	SubnetID *string  `json:"subnetID"`
+	NodeIDs  []string `json:"nodeIDs"`
+}
+
+type PeersParams struct {
+	NodeIDs []string `json:"nodeIDs"`
+}

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -739,7 +739,7 @@ func (p *TxDataParam) CacheKey() []string {
 
 type ValidatorParams struct {
 	ListParams ListParams
-	Rpc        string
+	RPC        string
 }
 
 func (p *ValidatorParams) ForValues(v uint8, q url.Values) error {
@@ -747,7 +747,7 @@ func (p *ValidatorParams) ForValues(v uint8, q url.Values) error {
 }
 
 func (p *ValidatorParams) SetParamInfo(v uint8, rpc string) error {
-	p.Rpc = rpc
+	p.RPC = rpc
 	return nil
 }
 

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -736,3 +736,21 @@ func (p *TxDataParam) ForValues(v uint8, q url.Values) error {
 func (p *TxDataParam) CacheKey() []string {
 	return p.ListParams.CacheKey()
 }
+
+type ValidatorParams struct {
+	ListParams ListParams
+	Rpc        string
+}
+
+func (p *ValidatorParams) ForValues(v uint8, q url.Values) error {
+	return p.ListParams.ForValues(v, q)
+}
+
+func (p *ValidatorParams) SetParamInfo(v uint8, rpc string) error {
+	p.Rpc = rpc
+	return nil
+}
+
+func (p *ValidatorParams) CacheKey() []string {
+	return p.ListParams.CacheKey()
+}

--- a/services/indexes/params/params.go
+++ b/services/indexes/params/params.go
@@ -47,6 +47,7 @@ const (
 	KeyOutputOutputType = "outputOutputType"
 	KeyOutputGroupID    = "outputGroupId"
 	KeyTransactionID    = "transactionId"
+	KeyRPC              = "rpc"
 
 	PaginationMaxLimit      = 5000
 	PaginationDefaultOffset = 0

--- a/utils/validator_info.go
+++ b/utils/validator_info.go
@@ -1,0 +1,208 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chain4travel/magellan/cfg"
+)
+
+func PeerIndex(peers *cfg.PeersResponse, nodeID string) int {
+	for idx, peer := range peers.Result.Peers {
+		if peer.NodeID == nodeID {
+			return idx
+		}
+	}
+	return -1
+}
+func GetDate(unixTime string) string {
+	//Date in Unix Format
+	unixDateInt, _ := strconv.ParseInt(unixTime, 10, 64)
+	//UnixDate in Time format struct
+	dateFTime := time.Unix(unixDateInt, 0)
+	return strings.Split(dateFTime.String(), " -")[0]
+}
+func getDuration(startTime string, endTime string) string {
+	start, _ := time.Parse("2006-01-02 15:04:05", startTime)
+	end, _ := time.Parse("2006-01-02 15:04:05", endTime)
+	difference := end.Sub(start)
+	duration := int(difference.Hours() / 24)
+	return strconv.Itoa(duration) + " Days"
+}
+
+func GetValidatorsGeoIPInfo(rpc string, geoIPConfig cfg.EndpointService) cfg.GeoIPValidators {
+	var validatorList []cfg.Validator
+	validators := GetCurrentValidators(rpc)
+	peers := GetPeers(rpc)
+	for i := 0; i < len(validators.Result.Validators); i++ {
+
+		validator := validators.Result.Validators[i]
+		indexPeerWithSameID := PeerIndex(&peers, validator.NodeID)
+		if indexPeerWithSameID >= 0 {
+			validatorList = append(validatorList, SetValidatorInfo(&validators.Result.Validators[i], &peers.Result.Peers[indexPeerWithSameID], true, geoIPConfig))
+		} else {
+			validatorList = append(validatorList, SetValidatorInfo(&validators.Result.Validators[i], nil, false, geoIPConfig))
+		}
+
+	}
+	geoValidatorsInfo := cfg.GeoIPValidators{
+		Name:  "GeoIPInfo",
+		Value: validatorList,
+	}
+	return geoValidatorsInfo
+}
+
+func SetValidatorInfo(validator *cfg.ValidatorInfo, peer *cfg.PeerInfo, peerFlag bool, config cfg.EndpointService) cfg.Validator {
+	startTime := GetDate(validator.StartTime)
+	endTime := GetDate(validator.EndTime)
+	var info cfg.Validator
+	if peerFlag {
+		geoIPInfo := GetLocationByIP(peer.IP, config)
+		info = cfg.Validator{
+			NodeID:     validator.NodeID,
+			IP:         peer.IP,
+			TxID:       validator.TxID,
+			Connected:  validator.Connected,
+			StartTime:  startTime,
+			EndTime:    endTime,
+			Duration:   getDuration(startTime, endTime),
+			Uptime:     validator.Uptime,
+			Country:    geoIPInfo.Country,
+			Lng:        geoIPInfo.Lon,
+			Lat:        geoIPInfo.Lat,
+			CountryISO: geoIPInfo.CountryCode,
+			City:       geoIPInfo.City,
+		}
+	} else {
+		info = cfg.Validator{
+			NodeID:     validator.NodeID,
+			IP:         "",
+			TxID:       validator.TxID,
+			Connected:  validator.Connected,
+			StartTime:  startTime,
+			EndTime:    endTime,
+			Duration:   getDuration(startTime, endTime),
+			Uptime:     validator.Uptime,
+			Country:    "",
+			Lng:        0.0,
+			Lat:        0.0,
+			CountryISO: "",
+			City:       "",
+		}
+	}
+	return info
+}
+func GetCurrentValidators(rpc string) cfg.ValidatorsResponse {
+	var response cfg.ValidatorsResponse
+	url := fmt.Sprintf("%s/ext/bc/P", rpc)
+	method := "POST"
+
+	payload := strings.NewReader(`{
+		"jsonrpc": "2.0",
+		"method": "platform.getCurrentValidators",
+		"params": {
+			"subnetID":null,
+			"nodeIDs":[]
+		},
+		"id": 1
+	}`)
+
+	client := &http.Client{}
+
+	req, err := http.NewRequest(method, url, payload)
+
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+
+	json.Unmarshal(body, &response)
+	return response
+}
+
+func GetPeers(rpc string) cfg.PeersResponse {
+	var response cfg.PeersResponse
+	url := fmt.Sprintf("%s/ext/info", rpc)
+	method := "POST"
+
+	payload := strings.NewReader(`{
+		"jsonrpc":"2.0",
+		"id"     :1,
+		"method" :"info.peers",
+		"params" :{
+			"nodeIDs": []
+		}
+	}`)
+
+	client := &http.Client{}
+
+	req, err := http.NewRequest(method, url, payload)
+
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+
+	json.Unmarshal(body, &response)
+	return response
+}
+
+func GetLocationByIP(ip string, config cfg.EndpointService) cfg.IPAPIResponse {
+
+	var response cfg.IPAPIResponse
+	ip = strings.Split(ip, ":")[0]
+	url := fmt.Sprintf("%s%s", config.UrlEndpoint, ip)
+	// Perform the HTTP GET request
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+
+	json.Unmarshal(body, &response)
+
+	return response
+}

--- a/utils/validator_info.go
+++ b/utils/validator_info.go
@@ -51,14 +51,14 @@ func GetValidatorsGeoIPInfo(rpc string, geoIPConfig *cfg.EndpointService) (model
 	}
 	pvmClient := platformvm.NewClient(rpc)
 	infoClient := info.NewClient(rpc)
-	validators,err := pvmClient.GetCurrentValidators(context.Background(),ids.ID{},[]ids.NodeID{})
+	validators, err := pvmClient.GetCurrentValidators(context.Background(), ids.ID{}, []ids.NodeID{})
 	if err != nil {
 		geoValidatorsInfo.Value = validatorList
 		return *geoValidatorsInfo, err
 	}
 	peers, _ := infoClient.Peers(context.Background())
-	for _,validator := range validators{
-		validatorGeoIPInfo := setValidatorInfo(&validator)
+	for _, validator := range validators {
+		validatorGeoIPInfo := setValidatorInfo(validator)
 		indexPeerWithSameID := PeerIndex(peers, validator.NodeID)
 		if indexPeerWithSameID >= 0 {
 			err = setGeoIPInfo(validatorGeoIPInfo, peers[indexPeerWithSameID].IP, geoIPConfig)
@@ -70,7 +70,7 @@ func GetValidatorsGeoIPInfo(rpc string, geoIPConfig *cfg.EndpointService) (model
 	return *geoValidatorsInfo, err
 }
 
-func setValidatorInfo(validator *platformvm.ClientPermissionlessValidator) *models.Validator {
+func setValidatorInfo(validator platformvm.ClientPermissionlessValidator) *models.Validator {
 	startTime, _ := GetDate(validator.StartTime)
 	endTime, _ := GetDate(validator.EndTime)
 	duration, _ := getDuration(validator.StartTime, validator.EndTime)

--- a/utils/validator_info.go
+++ b/utils/validator_info.go
@@ -14,8 +14,6 @@ import (
 	"github.com/chain4travel/magellan/models"
 )
 
-const timeLayout = "2006-01-02 15:04:05"
-
 func PeerIndex(peers *models.PeersResponse, nodeID string) int {
 	for idx, peer := range peers.Result.Peers {
 		if peer.NodeID == nodeID {
@@ -36,12 +34,17 @@ func GetDate(unixTime string) (string, error) {
 }
 
 func getDuration(startTime string, endTime string) (string, error) {
-	start, err := time.Parse(timeLayout, startTime)
 	const d = " Days"
+	unixDateInt, err := strconv.ParseInt(startTime, 10, 64)
+	if err != nil {
+		return "", err
+	}
+	start := time.Unix(unixDateInt, 0)
+	unixDateInt, err = strconv.ParseInt(endTime, 10, 64)
 	if err != nil {
 		return "- " + d, err
 	}
-	end, err := time.Parse(timeLayout, endTime)
+	end := time.Unix(unixDateInt, 0)
 	if err != nil {
 		return "- " + d, err
 	}
@@ -86,7 +89,7 @@ func GetValidatorsGeoIPInfo(rpc string, geoIPConfig *cfg.EndpointService) (model
 func setValidatorInfo(validator *models.ValidatorInfo) *models.Validator {
 	startTime, _ := GetDate(validator.StartTime)
 	endTime, _ := GetDate(validator.EndTime)
-	duration, _ := getDuration(startTime, endTime)
+	duration, _ := getDuration(validator.StartTime, validator.EndTime)
 	return &models.Validator{
 		NodeID:    validator.NodeID,
 		TxID:      validator.TxID,

--- a/utils/validator_info.go
+++ b/utils/validator_info.go
@@ -39,7 +39,6 @@ func GetValidatorsGeoIPInfo(rpc string, geoIPConfig cfg.EndpointService) cfg.Geo
 	validators := GetCurrentValidators(rpc)
 	peers := GetPeers(rpc)
 	for i := 0; i < len(validators.Result.Validators); i++ {
-
 		validator := validators.Result.Validators[i]
 		indexPeerWithSameID := PeerIndex(&peers, validator.NodeID)
 		if indexPeerWithSameID >= 0 {
@@ -186,7 +185,6 @@ func GetPeers(rpc string) cfg.PeersResponse {
 	return response
 }
 func GetLocationByIP(ip string, config cfg.EndpointService) cfg.IPAPIResponse {
-
 	var response cfg.IPAPIResponse
 	ip = strings.Split(ip, ":")[0]
 	url := fmt.Sprintf("%s%s", config.URLEndpoint, ip)

--- a/utils/validator_info.go
+++ b/utils/validator_info.go
@@ -34,7 +34,6 @@ func getDuration(startTime string, endTime string) string {
 	duration := int(difference.Hours() / 24)
 	return strconv.Itoa(duration) + " Days"
 }
-
 func GetValidatorsGeoIPInfo(rpc string, geoIPConfig cfg.EndpointService) cfg.GeoIPValidators {
 	var validatorList []cfg.Validator
 	validators := GetCurrentValidators(rpc)
@@ -48,7 +47,6 @@ func GetValidatorsGeoIPInfo(rpc string, geoIPConfig cfg.EndpointService) cfg.Geo
 		} else {
 			validatorList = append(validatorList, SetValidatorInfo(&validators.Result.Validators[i], nil, false, geoIPConfig))
 		}
-
 	}
 	geoValidatorsInfo := cfg.GeoIPValidators{
 		Name:  "GeoIPInfo",
@@ -180,35 +178,44 @@ func GetPeers(rpc string) cfg.PeersResponse {
 		return response
 	}
 
-	json.Unmarshal(body, &response)
+	err = json.Unmarshal(body, &response)
 	if err != nil {
 		fmt.Println(err)
 		return response
 	}
 	return response
 }
-
 func GetLocationByIP(ip string, config cfg.EndpointService) cfg.IPAPIResponse {
 
 	var response cfg.IPAPIResponse
 	ip = strings.Split(ip, ":")[0]
 	url := fmt.Sprintf("%s%s", config.URLEndpoint, ip)
 	// Perform the HTTP GET request
-	resp, err := http.Get(url)
+	client := &http.Client{}
+
+	req, err := http.NewRequest("GET", url, nil)
+
 	if err != nil {
 		fmt.Println(err)
 		return response
 	}
-	defer resp.Body.Close()
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	defer res.Body.Close()
 
 	// Read the response body
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		fmt.Println(err)
 		return response
 	}
 
-	json.Unmarshal(body, &response)
+	err = json.Unmarshal(body, &response)
 	if err != nil {
 		fmt.Println(err)
 		return response

--- a/utils/validator_info.go
+++ b/utils/validator_info.go
@@ -21,9 +21,9 @@ func PeerIndex(peers *cfg.PeersResponse, nodeID string) int {
 	return -1
 }
 func GetDate(unixTime string) string {
-	//Date in Unix Format
+	// Date in Unix Format
 	unixDateInt, _ := strconv.ParseInt(unixTime, 10, 64)
-	//UnixDate in Time format struct
+	// UnixDate in Time format struct
 	dateFTime := time.Unix(unixDateInt, 0)
 	return strings.Split(dateFTime.String(), " -")[0]
 }
@@ -100,7 +100,6 @@ func SetValidatorInfo(validator *cfg.ValidatorInfo, peer *cfg.PeerInfo, peerFlag
 func GetCurrentValidators(rpc string) cfg.ValidatorsResponse {
 	var response cfg.ValidatorsResponse
 	url := fmt.Sprintf("%s/ext/bc/P", rpc)
-	method := "POST"
 
 	payload := strings.NewReader(`{
 		"jsonrpc": "2.0",
@@ -114,7 +113,7 @@ func GetCurrentValidators(rpc string) cfg.ValidatorsResponse {
 
 	client := &http.Client{}
 
-	req, err := http.NewRequest(method, url, payload)
+	req, err := http.NewRequest("POST", url, payload)
 
 	if err != nil {
 		fmt.Println(err)
@@ -137,14 +136,17 @@ func GetCurrentValidators(rpc string) cfg.ValidatorsResponse {
 		return response
 	}
 
-	json.Unmarshal(body, &response)
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
 	return response
 }
 
 func GetPeers(rpc string) cfg.PeersResponse {
 	var response cfg.PeersResponse
 	url := fmt.Sprintf("%s/ext/info", rpc)
-	method := "POST"
 
 	payload := strings.NewReader(`{
 		"jsonrpc":"2.0",
@@ -157,7 +159,7 @@ func GetPeers(rpc string) cfg.PeersResponse {
 
 	client := &http.Client{}
 
-	req, err := http.NewRequest(method, url, payload)
+	req, err := http.NewRequest("POST", url, payload)
 
 	if err != nil {
 		fmt.Println(err)
@@ -179,6 +181,10 @@ func GetPeers(rpc string) cfg.PeersResponse {
 	}
 
 	json.Unmarshal(body, &response)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
 	return response
 }
 
@@ -186,7 +192,7 @@ func GetLocationByIP(ip string, config cfg.EndpointService) cfg.IPAPIResponse {
 
 	var response cfg.IPAPIResponse
 	ip = strings.Split(ip, ":")[0]
-	url := fmt.Sprintf("%s%s", config.UrlEndpoint, ip)
+	url := fmt.Sprintf("%s%s", config.URLEndpoint, ip)
 	// Perform the HTTP GET request
 	resp, err := http.Get(url)
 	if err != nil {
@@ -203,6 +209,10 @@ func GetLocationByIP(ip string, config cfg.EndpointService) cfg.IPAPIResponse {
 	}
 
 	json.Unmarshal(body, &response)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
 
 	return response
 }


### PR DESCRIPTION
**Description:**
**1.** A new endpoint was added to unify the information of the validators list (connected and disconnected) with their geographical location based on their ip.
To obtain this information we are querying the endpoint getCurrentValidators and getPeers, and unify the data of both in this single endpoint.
**E.g.**
**Validator Disconnected**
{
  "name": "GeoIPInfo",
  "value": [
    {
      "nodeID": "NodeID-xxxxxxxx",
      "IP": "",
      "txID": "xxxxxxxx",
      "connected": false,
      "startTime": "2022-12-05 04:04:20",
      "endTime": "2022-12-28 04:12:14",
      "duration": "23 Days",
      "uptime": "0.0152",
      "country": "",
      "lng": 0,
      "lat": 0,
      "countryISO": "",
      "city": ""
    }]
   }
**Validator Connected**
{
  "name": "GeoIPInfo",
  "value": [
       {
          "nodeID": "NodeID-xxxxx",
          "IP": "xxx.xxx.xxx.xxx:xxxx",
          "txID": "xxxxxxx",
          "connected": true,
          "startTime": "2022-08-24 07:52:51",
          "endTime": "2022-12-31 09:02:12",
          "duration": "129 Days",
          "uptime": "0.9999",
          "country": "Germany",
          "lng": 12.365,
          "lat": 50.475,
          "countryISO": "DE",
          "city": "Falkenstein"
   }]
}

**2.** For the configuration of this endpoint, a new option was added in the services section of the config file, in which the url of the GeoIp service and its respective token must be specified. 
...
   "services": {
    "db": {
      "dsn": "",
      "driver": ""
    },
    "geoIP": {
      "urlEndpoint":"http://ip-api.com/json/",
      "autorizationToken": ""
    }
   