### PR TITLE
[TECH 482] Co2 Emissions Service

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -41,6 +41,23 @@ func WriteErr(w http.ResponseWriter, code int, msg string) {
 	_, _ = w.Write(errBytes)
 }
 
+func ParseGetBodyJSON(r *web.Request) (url.Values, error) {
+	var data map[string]interface{}
+	output := url.Values{}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return output, err
+	}
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return output, err
+	}
+	for k, v := range data {
+		output.Set(k, v.(string))
+	}
+	return output, nil
+}
+
 func ParseGetJSON(r *web.Request, n int64) (url.Values, error) {
 	if r == nil {
 		return r.URL.Query(), nil

--- a/api/v2.go
+++ b/api/v2.go
@@ -153,12 +153,12 @@ func (c *V2Context) DailyEmissions(w web.ResponseWriter, r *web.Request) {
 		return
 	}
 
-	key := fmt.Sprintf("Daily Emissions %s", p.EndDate)
+	key := fmt.Sprintf("Daily Emissions %s", p.ListParams.EndTime)
 	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams(key, p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetDailyEmissios(p.StartDate, p.EndDate, c.sc.Services.InmutableInsights), nil
+			return utils.GetDailyEmissios(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights), nil
 		},
 	})
 }
@@ -169,12 +169,12 @@ func (c *V2Context) NetworkEmissions(w web.ResponseWriter, r *web.Request) {
 		c.WriteErr(w, 400, err)
 		return
 	}
-	key := fmt.Sprintf("Network Emissions %s", p.EndDate)
+	key := fmt.Sprintf("Network Emissions %s", p.ListParams.EndTime)
 	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams(key, p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetNetworkEmissions(p.StartDate, p.EndDate, c.sc.Services.InmutableInsights), nil
+			return utils.GetNetworkEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights), nil
 		},
 	})
 }
@@ -185,12 +185,12 @@ func (c *V2Context) TransactionEmissions(w web.ResponseWriter, r *web.Request) {
 		c.WriteErr(w, 400, err)
 		return
 	}
-	key := fmt.Sprintf("Transaction Emissions %s", p.EndDate)
+	key := fmt.Sprintf("Transaction Emissions %s", p.ListParams.EndTime)
 	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams(key, p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetNetworkEmissionsPerTransaction(p.StartDate, p.EndDate, c.sc.Services.InmutableInsights), nil
+			return utils.GetNetworkEmissionsPerTransaction(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights), nil
 		},
 	})
 }

--- a/api/v2.go
+++ b/api/v2.go
@@ -116,9 +116,9 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 		Get("/transactions/aggregates", (*V2Context).Aggregate).
 		Get("/addressChains", (*V2Context).AddressChains).
 		Post("/addressChains", (*V2Context).AddressChainsPost).
-		Post("/dailyEmissions", (*V2Context).DailyEmissions).
-		Post("/networkEmissions", (*V2Context).NetworkEmissions).
-		Post("/transactionEmissions", (*V2Context).TransactionEmissions).
+		Get("/dailyEmissions", (*V2Context).DailyEmissions).
+		Get("/networkEmissions", (*V2Context).NetworkEmissions).
+		Get("/transactionEmissions", (*V2Context).TransactionEmissions).
 
 		// List and Get routes
 		Get("/transactions", (*V2Context).ListTransactions).
@@ -148,12 +148,7 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 
 func (c *V2Context) DailyEmissions(w web.ResponseWriter, r *web.Request) {
 	p := &params.EmissionsParams{}
-	q, err := ParseGetBodyJSON(r)
-	if err != nil {
-		c.WriteErr(w, 400, err)
-		return
-	}
-	if err := p.ForValues(c.version, q); err != nil {
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
 		c.WriteErr(w, 400, err)
 		return
 	}
@@ -169,12 +164,7 @@ func (c *V2Context) DailyEmissions(w web.ResponseWriter, r *web.Request) {
 
 func (c *V2Context) NetworkEmissions(w web.ResponseWriter, r *web.Request) {
 	p := &params.EmissionsParams{}
-	q, err := ParseGetBodyJSON(r)
-	if err != nil {
-		c.WriteErr(w, 400, err)
-		return
-	}
-	if err := p.ForValues(c.version, q); err != nil {
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
 		c.WriteErr(w, 400, err)
 		return
 	}
@@ -184,19 +174,14 @@ func (c *V2Context) NetworkEmissions(w web.ResponseWriter, r *web.Request) {
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams(key, p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetNetworkEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode), nil
+			return utils.GetNetworkEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode)
 		},
 	})
 }
 
 func (c *V2Context) TransactionEmissions(w web.ResponseWriter, r *web.Request) {
 	p := &params.EmissionsParams{}
-	q, err := ParseGetBodyJSON(r)
-	if err != nil {
-		c.WriteErr(w, 400, err)
-		return
-	}
-	if err := p.ForValues(c.version, q); err != nil {
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
 		c.WriteErr(w, 400, err)
 		return
 	}
@@ -205,7 +190,7 @@ func (c *V2Context) TransactionEmissions(w web.ResponseWriter, r *web.Request) {
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams(key, p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetNetworkEmissionsPerTransaction(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode), nil
+			return utils.GetNetworkEmissionsPerTransaction(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode)
 		},
 	})
 }

--- a/api/v2.go
+++ b/api/v2.go
@@ -148,27 +148,37 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 
 func (c *V2Context) DailyEmissions(w web.ResponseWriter, r *web.Request) {
 	p := &params.EmissionsParams{}
-	if err := p.SetEmissionsParams(1); err != nil {
+	q, err := ParseGetBodyJSON(r)
+	if err != nil {
 		c.WriteErr(w, 400, err)
 		return
 	}
-
+	if err := p.ForValues(c.version, q); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
 	key := fmt.Sprintf("Daily Emissions %s", p.ListParams.EndTime)
 	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams(key, p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetDailyEmissios(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights), nil
+			return utils.GetDailyEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights), nil
 		},
 	})
 }
 
 func (c *V2Context) NetworkEmissions(w web.ResponseWriter, r *web.Request) {
 	p := &params.EmissionsParams{}
-	if err := p.SetEmissionsParams(7); err != nil {
+	q, err := ParseGetBodyJSON(r)
+	if err != nil {
 		c.WriteErr(w, 400, err)
 		return
 	}
+	if err := p.ForValues(c.version, q); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
 	key := fmt.Sprintf("Network Emissions %s", p.ListParams.EndTime)
 	c.WriteCacheable(w, caching.Cacheable{
 		TTL: 24 * time.Hour,
@@ -181,7 +191,12 @@ func (c *V2Context) NetworkEmissions(w web.ResponseWriter, r *web.Request) {
 
 func (c *V2Context) TransactionEmissions(w web.ResponseWriter, r *web.Request) {
 	p := &params.EmissionsParams{}
-	if err := p.SetEmissionsParams(7); err != nil {
+	q, err := ParseGetBodyJSON(r)
+	if err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	if err := p.ForValues(c.version, q); err != nil {
 		c.WriteErr(w, 400, err)
 		return
 	}

--- a/api/v2.go
+++ b/api/v2.go
@@ -162,7 +162,7 @@ func (c *V2Context) DailyEmissions(w web.ResponseWriter, r *web.Request) {
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams(key, p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetDailyEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights), nil
+			return utils.GetDailyEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode), nil
 		},
 	})
 }
@@ -184,7 +184,7 @@ func (c *V2Context) NetworkEmissions(w web.ResponseWriter, r *web.Request) {
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams(key, p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetNetworkEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights), nil
+			return utils.GetNetworkEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode), nil
 		},
 	})
 }
@@ -205,7 +205,7 @@ func (c *V2Context) TransactionEmissions(w web.ResponseWriter, r *web.Request) {
 		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams(key, p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return utils.GetNetworkEmissionsPerTransaction(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights), nil
+			return utils.GetNetworkEmissionsPerTransaction(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode), nil
 		},
 	})
 }

--- a/api/v2.go
+++ b/api/v2.go
@@ -119,6 +119,7 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 		Get("/dailyEmissions", (*V2Context).DailyEmissions).
 		Get("/networkEmissions", (*V2Context).NetworkEmissions).
 		Get("/transactionEmissions", (*V2Context).TransactionEmissions).
+		Get("/countryEmissions", (*V2Context).CountryEmissions).
 
 		// List and Get routes
 		Get("/transactions", (*V2Context).ListTransactions).
@@ -158,6 +159,22 @@ func (c *V2Context) DailyEmissions(w web.ResponseWriter, r *web.Request) {
 		Key: c.cacheKeyForParams(key, p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return utils.GetDailyEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode), nil
+		},
+	})
+}
+
+func (c *V2Context) CountryEmissions(w web.ResponseWriter, r *web.Request) {
+	p := &params.EmissionsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("Daily Emissions %s", p.ListParams.EndTime)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 24 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return utils.GetCountryEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode)
 		},
 	})
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -94,7 +94,7 @@ type Services struct {
 }
 
 type EndpointService struct {
-	URLEndpoint       string `json:"urlEndpoint"`
+	URLEndpoint        string `json:"urlEndpoint"`
 	AuthorizationToken string `json:"autorizationToken"`
 }
 
@@ -146,7 +146,7 @@ func NewFromFile(filePath string) (*Config, error) {
 	}
 
 	urlEndpointInmutable := servicesInmutableViper.GetString(keyServicesEndpoint)
-	tokenInmutable := GetEnvConfig(fmt.Sprintf("%sInmutable",keyServicesToken))
+	tokenInmutable := GetEnvConfig(fmt.Sprintf("%sInmutable", keyServicesToken))
 
 	features := v.GetStringSlice(keysFeatures)
 	featuresMap := make(map[string]struct{})
@@ -180,7 +180,7 @@ func NewFromFile(filePath string) (*Config, error) {
 				RODSN:  dbrodsn,
 			},
 			InmutableInsights: EndpointService{
-				URLEndpoint:       urlEndpointInmutable,
+				URLEndpoint:        urlEndpointInmutable,
 				AuthorizationToken: tokenInmutable,
 			},
 		},

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -16,6 +16,7 @@ package cfg
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -94,7 +95,7 @@ type Services struct {
 }
 
 type EndpointService struct {
-	URLEndpoint       string `json:"urlEndpoint"`
+	URLEndpoint        string `json:"urlEndpoint"`
 	AuthorizationToken string `json:"autorizationToken"`
 }
 
@@ -146,7 +147,7 @@ func NewFromFile(filePath string) (*Config, error) {
 	}
 
 	urlEndpointInmutable := servicesInmutableViper.GetString(keyServicesEndpoint)
-	tokenInmutable := GetEnvConfig(fmt.Sprintf("%sInmutable",keyServicesToken))
+	tokenInmutable := os.Getenv(fmt.Sprintf("%sInmutable", keyServicesToken))
 
 	features := v.GetStringSlice(keysFeatures)
 	featuresMap := make(map[string]struct{})
@@ -180,7 +181,7 @@ func NewFromFile(filePath string) (*Config, error) {
 				RODSN:  dbrodsn,
 			},
 			InmutableInsights: EndpointService{
-				URLEndpoint:       urlEndpointInmutable,
+				URLEndpoint:        urlEndpointInmutable,
 				AuthorizationToken: tokenInmutable,
 			},
 		},

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -97,12 +97,6 @@ type EndpointService struct {
 	AutorizationToken string `json:"autorizationToken"`
 }
 
-type Emissions struct {
-	Chain string  `json:"chain"`
-	Time  string  `json:"time"`
-	Value float64 `json:"value"`
-}
-
 type API struct {
 	ListenAddr string `json:"listenAddr"`
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -15,6 +15,7 @@ package cfg
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -94,7 +95,7 @@ type Services struct {
 
 type EndpointService struct {
 	URLEndpoint       string `json:"urlEndpoint"`
-	AutorizationToken string `json:"autorizationToken"`
+	AuthorizationToken string `json:"autorizationToken"`
 }
 
 type API struct {
@@ -145,7 +146,7 @@ func NewFromFile(filePath string) (*Config, error) {
 	}
 
 	urlEndpointInmutable := servicesInmutableViper.GetString(keyServicesEndpoint)
-	tokenInmutable := servicesInmutableViper.GetString(keyServicesToken)
+	tokenInmutable := GetEnvConfig(fmt.Sprintf("%sInmutable",keyServicesToken))
 
 	features := v.GetStringSlice(keysFeatures)
 	featuresMap := make(map[string]struct{})
@@ -180,7 +181,7 @@ func NewFromFile(filePath string) (*Config, error) {
 			},
 			InmutableInsights: EndpointService{
 				URLEndpoint:       urlEndpointInmutable,
-				AutorizationToken: tokenInmutable,
+				AuthorizationToken: tokenInmutable,
 			},
 		},
 		CchainID:            v.GetString(keysStreamProducerCchainID),

--- a/cfg/helpers.go
+++ b/cfg/helpers.go
@@ -6,9 +6,7 @@ package cfg
 import (
 	"bytes"
 	"log"
-	"os"
 
-	"github.com/joho/godotenv"
 	"github.com/spf13/viper"
 )
 
@@ -85,11 +83,4 @@ func newChainsConfig(v *viper.Viper) (Chains, error) {
 		chains[id] = Chain{ID: id, VMType: vmType}
 	}
 	return chains, nil
-}
-func GetEnvConfig(envKey string)string{
-	err := godotenv.Load("local.env")
-	if err != nil {
-		log.Fatalf("Some error occured. Err: %s", err)
-	}
-	return os.Getenv(envKey)
 }

--- a/cfg/helpers.go
+++ b/cfg/helpers.go
@@ -6,7 +6,9 @@ package cfg
 import (
 	"bytes"
 	"log"
+	"os"
 
+	"github.com/joho/godotenv"
 	"github.com/spf13/viper"
 )
 
@@ -83,4 +85,11 @@ func newChainsConfig(v *viper.Viper) (Chains, error) {
 		chains[id] = Chain{ID: id, VMType: vmType}
 	}
 	return chains, nil
+}
+func GetEnvConfig(envKey string)string{
+	err := godotenv.Load("local.env")
+	if err != nil {
+		log.Fatalf("Some error occured. Err: %s", err)
+	}
+	return os.Getenv(envKey)
 }

--- a/cfg/helpers.go
+++ b/cfg/helpers.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/joho/godotenv"
 	"github.com/spf13/viper"
 )
 
@@ -86,10 +85,6 @@ func newChainsConfig(v *viper.Viper) (Chains, error) {
 	}
 	return chains, nil
 }
-func GetEnvConfig(envKey string)string{
-	err := godotenv.Load("local.env")
-	if err != nil {
-		log.Fatalf("Some error occured. Err: %s", err)
-	}
+func GetEnvConfig(envKey string) string {
 	return os.Getenv(envKey)
 }

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -33,6 +33,10 @@ const (
 	keysServicesDBDSN    = "dsn"
 	keysServicesDBRODSN  = "ro_dsn"
 
+	keyServicesInmutable = "inmutableInsights"
+	keyServicesEndpoint  = "urlEndpoint"
+	keyServicesToken     = "autorizationToken"
+
 	keysStreamProducerCaminoNode   = "caminoNode"
 	keysStreamProducerNodeInstance = "nodeInstance"
 

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -35,7 +35,7 @@ const (
 
 	keyServicesInmutable = "inmutableInsights"
 	keyServicesEndpoint  = "urlEndpoint"
-	keyServicesToken     = "autorizationToken"
+	keyServicesToken     = "authorizationToken"
 
 	keysStreamProducerCaminoNode   = "caminoNode"
 	keysStreamProducerNodeInstance = "nodeInstance"

--- a/docker/columbus/config.json
+++ b/docker/columbus/config.json
@@ -27,7 +27,7 @@
       "driver": "mysql"
     },
     "inmutableInsights": {
-      "urlEndpoint":"https://co2.api.immutableinsight.io/co2",
+      "urlEndpoint":"https://co2.api.immutableinsight.io",
       "autorizationToken": ""
     }
   }

--- a/docker/columbus/config.json
+++ b/docker/columbus/config.json
@@ -25,6 +25,10 @@
     "db": {
       "dsn": "root:password@tcp(mysql:3306)/magellan_columbus",
       "driver": "mysql"
+    },
+    "inmutableInsights": {
+      "urlEndpoint":"https://co2.api.immutableinsight.io/co2",
+      "autorizationToken": ""
     }
   }
 }

--- a/docker/config.json
+++ b/docker/config.json
@@ -24,6 +24,10 @@
     "db": {
       "dsn": "root:password@tcp(mysql:3306)/magellan",
       "driver": "mysql"
+    },
+    "inmutableInsights": {
+      "urlEndpoint":"https://co2.api.immutableinsight.io/co2",
+      "autorizationToken": ""
     }
   }
 }

--- a/docker/config.json
+++ b/docker/config.json
@@ -26,7 +26,7 @@
       "driver": "mysql"
     },
     "inmutableInsights": {
-      "urlEndpoint":"https://co2.api.immutableinsight.io/co2",
+      "urlEndpoint":"https://co2.api.immutableinsight.io",
       "autorizationToken": ""
     }
   }

--- a/docker/standalone/config.standalone.json
+++ b/docker/standalone/config.standalone.json
@@ -25,7 +25,7 @@
       "driver": "mysql"
     },
     "inmutableInsights": {
-      "urlEndpoint": "https://co2.api.immutableinsight.io/co2",
+      "urlEndpoint": "https://co2.api.immutableinsight.io",
       "autorizationToken": ""
     }
   }

--- a/docker/standalone/config.standalone.json
+++ b/docker/standalone/config.standalone.json
@@ -2,8 +2,7 @@
   "networkID": 1001,
   "logDirectory": "/var/log/magellan",
   "listenAddr": ":8080",
-  "features": [
-  ],
+  "features": [],
   "caminoNode": "http://camino:9650",
   "nodeInstance": "default",
   "chains": {
@@ -24,6 +23,10 @@
     "db": {
       "dsn": "root:password@tcp(mysql:3306)/magellan",
       "driver": "mysql"
+    },
+    "inmutableInsights": {
+      "urlEndpoint": "https://co2.api.immutableinsight.io/co2",
+      "autorizationToken": ""
     }
   }
 }

--- a/models/collections.go
+++ b/models/collections.go
@@ -252,6 +252,13 @@ type AssetAggregate struct {
 	Aggregate *AggregatesHistogram `json:"aggregate"`
 }
 
+type NetworkNameResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  struct {
+		NetworkName string `json:"networkName"`
+	} `json:"result"`
+}
+
 /*******************  Merging  ***********************/
 
 type AggregateMerge interface {

--- a/models/collections.go
+++ b/models/collections.go
@@ -47,8 +47,14 @@ type EmissionsResult struct {
 }
 
 type Emissions struct {
-	Name  string            `json:"name"`
-	Value []EmissionsResult `json:"value"`
+	Name   string      `json:"name"`
+	Filter string      `jsont:"filter"`
+	Value  interface{} `json:"value"`
+}
+
+type CountryEmissionsResult struct {
+	Country string  `json:"Country"`
+	Value   float64 `json:"Value"`
 }
 
 type CTransactionData struct {

--- a/models/collections.go
+++ b/models/collections.go
@@ -40,6 +40,16 @@ type TransactionList struct {
 
 	Next *string `json:"next,omitempty"`
 }
+type EmissionsResult struct {
+	Chain string  `json:"chain"`
+	Time  string  `json:"time"`
+	Value float64 `json:"value"`
+}
+
+type Emissions struct {
+	Name  string            `json:"name"`
+	Value []EmissionsResult `json:"value"`
+}
 
 type CTransactionData struct {
 	Type      int       `json:"type"`

--- a/models/platform.go
+++ b/models/platform.go
@@ -30,3 +30,10 @@ type BlockList struct {
 	ListMetadata
 	Blocks []*Block `json:"blocks"`
 }
+
+type BodyRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params"`
+	ID      int         `json:"id"`
+}

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -10,7 +10,6 @@
 // **********************************************************
 // (c) 2021, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
-
 package params
 
 import (
@@ -62,26 +61,24 @@ func (p *SearchParams) CacheKey() []string {
 type EmissionsParams struct {
 	ListParams    ListParams
 	SubstractDays int
-	StartDate     string
-	EndDate       string
 }
 
 func (p *EmissionsParams) ForValues(v uint8, q url.Values) error {
 	if err := p.ListParams.ForValues(v, q); err != nil {
 		return err
 	}
-	p.StartDate, p.EndDate = Date(p.SubstractDays)
+	p.ListParams.StartTime, p.ListParams.EndTime = Date(p.SubstractDays)
 	return p.ListParams.ForValues(v, q)
 }
 func (p *EmissionsParams) SetEmissionsParams(substractDays int) error {
 	p.SubstractDays = substractDays
-	p.StartDate, p.EndDate = Date(p.SubstractDays)
+	p.ListParams.StartTime, p.ListParams.EndTime = Date(p.SubstractDays)
 	return nil
 }
 
 func (p *EmissionsParams) ForValuesInterface(v uint8, q map[string]interface{}) error {
-	p.StartDate = q["startDate"].(string)
-	p.EndDate = q["endDate"].(string)
+	p.ListParams.StartTime = q["startDate"].(time.Time)
+	p.ListParams.EndTime = q["endDate"].(time.Time)
 	return nil
 }
 
@@ -767,10 +764,10 @@ func (p *TxDataParam) CacheKey() []string {
 	return p.ListParams.CacheKey()
 }
 
-func Date(s int) (string, string) {
+func Date(s int) (time.Time, time.Time) {
 	now := time.Now()
-	nowF := now.Format("2006-01-02")
-	daysAgo := now.AddDate(0, 0, -s)
-	daysAgoF := daysAgo.Format("2006-01-02")
-	return daysAgoF, nowF
+	dateWithoutHour := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	daysAgo := dateWithoutHour.AddDate(0, 0, -s)
+	daysAgoF := time.Date(daysAgo.Year(), daysAgo.Month(), daysAgo.Day(), 0, 0, 0, 0, daysAgo.Location())
+	return daysAgoF, dateWithoutHour
 }

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -70,12 +70,6 @@ func (p *EmissionsParams) ForValues(v uint8, q url.Values) error {
 	return p.ListParams.ForValues(v, q)
 }
 
-func (p *EmissionsParams) ForValuesInterface(v uint8, q map[string]interface{}) error {
-	p.ListParams.StartTime = q["startDate"].(time.Time)
-	p.ListParams.EndTime = q["endDate"].(time.Time)
-	return nil
-}
-
 func (p *EmissionsParams) CacheKey() []string {
 	return p.ListParams.CacheKey()
 }
@@ -757,11 +751,3 @@ func (p *TxDataParam) ForValues(v uint8, q url.Values) error {
 func (p *TxDataParam) CacheKey() []string {
 	return p.ListParams.CacheKey()
 }
-
-/* func Date(s int) (time.Time, time.Time) {
-	now := time.Now()
-	dateWithoutHour := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	daysAgo := dateWithoutHour.AddDate(0, 0, -s)
-	daysAgoF := time.Date(daysAgo.Year(), daysAgo.Month(), daysAgo.Day(), 0, 0, 0, 0, daysAgo.Location())
-	return daysAgoF, dateWithoutHour
-} */

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -59,6 +59,36 @@ func (p *SearchParams) CacheKey() []string {
 	return p.ListParams.CacheKey()
 }
 
+type EmissionsParams struct {
+	ListParams    ListParams
+	SubstractDays int
+	StartDate     string
+	EndDate       string
+}
+
+func (p *EmissionsParams) ForValues(v uint8, q url.Values) error {
+	if err := p.ListParams.ForValues(v, q); err != nil {
+		return err
+	}
+	p.StartDate, p.EndDate = Date(p.SubstractDays)
+	return p.ListParams.ForValues(v, q)
+}
+func (p *EmissionsParams) SetEmissionsParams(substractDays int) error {
+	p.SubstractDays = substractDays
+	p.StartDate, p.EndDate = Date(p.SubstractDays)
+	return nil
+}
+
+func (p *EmissionsParams) ForValuesInterface(v uint8, q map[string]interface{}) error {
+	p.StartDate = q["startDate"].(string)
+	p.EndDate = q["endDate"].(string)
+	return nil
+}
+
+func (p *EmissionsParams) CacheKey() []string {
+	return p.ListParams.CacheKey()
+}
+
 type TxfeeAggregateParams struct {
 	ListParams ListParams
 
@@ -735,4 +765,12 @@ func (p *TxDataParam) ForValues(v uint8, q url.Values) error {
 
 func (p *TxDataParam) CacheKey() []string {
 	return p.ListParams.CacheKey()
+}
+
+func Date(s int) (string, string) {
+	now := time.Now()
+	nowF := now.Format("2006-01-02")
+	daysAgo := now.AddDate(0, 0, -s)
+	daysAgoF := daysAgo.Format("2006-01-02")
+	return daysAgoF, nowF
 }

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -67,13 +67,7 @@ func (p *EmissionsParams) ForValues(v uint8, q url.Values) error {
 	if err := p.ListParams.ForValues(v, q); err != nil {
 		return err
 	}
-	p.ListParams.StartTime, p.ListParams.EndTime = Date(p.SubstractDays)
 	return p.ListParams.ForValues(v, q)
-}
-func (p *EmissionsParams) SetEmissionsParams(substractDays int) error {
-	p.SubstractDays = substractDays
-	p.ListParams.StartTime, p.ListParams.EndTime = Date(p.SubstractDays)
-	return nil
 }
 
 func (p *EmissionsParams) ForValuesInterface(v uint8, q map[string]interface{}) error {
@@ -764,10 +758,10 @@ func (p *TxDataParam) CacheKey() []string {
 	return p.ListParams.CacheKey()
 }
 
-func Date(s int) (time.Time, time.Time) {
+/* func Date(s int) (time.Time, time.Time) {
 	now := time.Now()
 	dateWithoutHour := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	daysAgo := dateWithoutHour.AddDate(0, 0, -s)
 	daysAgoF := time.Date(daysAgo.Year(), daysAgo.Month(), daysAgo.Day(), 0, 0, 0, 0, daysAgo.Location())
 	return daysAgoF, dateWithoutHour
-}
+} */

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -67,7 +67,8 @@ func (p *EmissionsParams) ForValues(v uint8, q url.Values) error {
 	if err := p.ListParams.ForValues(v, q); err != nil {
 		return err
 	}
-	return p.ListParams.ForValues(v, q)
+	p.SubstractDays = int(p.ListParams.EndTime.Sub(p.ListParams.StartTime).Hours()) / 24
+	return nil
 }
 
 func (p *EmissionsParams) CacheKey() []string {

--- a/utils/emissions.go
+++ b/utils/emissions.go
@@ -51,7 +51,7 @@ func CarbonIntensityFactor(chain string, startDate string, endDate string, confi
 	if err != nil {
 		return response
 	}
-	req.Header.Add("Authorization", config.AutorizationToken)
+	req.Header.Add("Authorization", config.AuthorizationToken)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -80,7 +80,7 @@ func network(chain string, startDate string, endDate string, config cfg.Endpoint
 		fmt.Println(err)
 		return response
 	}
-	req.Header.Add("Authorization", config.AutorizationToken)
+	req.Header.Add("Authorization", config.AuthorizationToken)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -123,7 +123,7 @@ func transaction(chain string, startDate string, endDate string, config cfg.Endp
 		fmt.Println(err)
 		return response
 	}
-	req.Header.Add("Authorization", config.AutorizationToken)
+	req.Header.Add("Authorization", config.AuthorizationToken)
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/utils/emissions.go
+++ b/utils/emissions.go
@@ -1,0 +1,150 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/chain4travel/magellan/cfg"
+)
+
+// TODO: change the variable to constant
+var chainNames = [19]string{"algorand", "avalanche", "bitcoin", "caminocolumbus", "cardano", "cosmos", "kava", "polkadot", "solana", "tezos", "tron"}
+
+func GetDailyEmissios(startDate string, endDate string, config cfg.EndpointService) []cfg.Emissions {
+	var dailyEmissions []cfg.Emissions
+	for _, chain := range chainNames {
+		intensityFactor := CarbonIntensityFactor(chain, startDate, endDate, config)
+		if len(intensityFactor) > 0 {
+			dailyEmissions = append(dailyEmissions, intensityFactor[0])
+		}
+	}
+	return dailyEmissions
+}
+
+func GetNetworkEmissions(startDate string, endDate string, config cfg.EndpointService) []cfg.Emissions {
+	return network(chainNames[3], startDate, endDate, config)
+}
+func GetNetworkEmissionsPerTransaction(startDate string, endDate string, config cfg.EndpointService) []cfg.Emissions {
+	return transaction(chainNames[3], startDate, endDate, config)
+}
+
+func CarbonIntensityFactor(chain string, startDate string, endDate string, config cfg.EndpointService) []cfg.Emissions {
+	var response []cfg.Emissions
+	url := fmt.Sprintf("%s/carbon-intensity-factor?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	req.Header.Add("Authorization", config.AutorizationToken)
+
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	return response
+}
+
+func network(chain string, startDate string, endDate string, config cfg.EndpointService) []cfg.Emissions {
+	var response []cfg.Emissions
+	url := fmt.Sprintf("%s/network?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	req.Header.Add("Authorization", config.AutorizationToken)
+
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	for i, Value := range response {
+		formatValue := strconv.FormatFloat(Value.Value, 'f', 2, 64)
+		parsedValue, err := strconv.ParseFloat(formatValue, 64)
+
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		response[i].Value = parsedValue
+	}
+	return response
+}
+
+func transaction(chain string, startDate string, endDate string, config cfg.EndpointService) []cfg.Emissions {
+	var response []cfg.Emissions
+	url := fmt.Sprintf("%s/transaction?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	req.Header.Add("Authorization", config.AutorizationToken)
+
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		fmt.Println(err)
+		return response
+	}
+	for i, Value := range response {
+		formatValue := strconv.FormatFloat(Value.Value, 'f', 2, 64)
+		parsedValue, err := strconv.ParseFloat(formatValue, 64)
+
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		response[i].Value = parsedValue
+	}
+	return response
+}

--- a/utils/emissions.go
+++ b/utils/emissions.go
@@ -25,6 +25,9 @@ func GetDailyEmissios(startDate time.Time, endDate time.Time, config cfg.Endpoin
 			dailyEmissions = append(dailyEmissions, intensityFactor[0])
 		}
 	}
+	if dailyEmissions == nil {
+		return models.Emissions{Name: "Daily Emissions", Value: []models.EmissionsResult{}}
+	}
 	return models.Emissions{Name: "Daily Emissions", Value: dailyEmissions}
 }
 
@@ -32,13 +35,19 @@ func GetNetworkEmissions(startDate time.Time, endDate time.Time, config cfg.Endp
 	startDatef := startDate.Format("2006-01-02")
 	endDatef := endDate.Format("2006-01-02")
 	emissionsResult := network(chainNames[3], startDatef, endDatef, config)
+	if emissionsResult == nil {
+		return models.Emissions{Name: "Network Emissions", Value: []models.EmissionsResult{}}
+	}
 	return models.Emissions{Name: "Network Emissions", Value: emissionsResult}
 }
 func GetNetworkEmissionsPerTransaction(startDate time.Time, endDate time.Time, config cfg.EndpointService) models.Emissions {
 	startDatef := startDate.Format("2006-01-02")
 	endDatef := endDate.Format("2006-01-02")
 	emissionsResult := transaction(chainNames[3], startDatef, endDatef, config)
-	return models.Emissions{Name: "Transactions Emissions", Value: emissionsResult}
+	if emissionsResult == nil {
+		return models.Emissions{Name: "Network Emissions per Transaction", Value: []models.EmissionsResult{}}
+	}
+	return models.Emissions{Name: "Network Emissions per Transaction", Value: emissionsResult}
 }
 
 func CarbonIntensityFactor(chain string, startDate string, endDate string, config cfg.EndpointService) []models.EmissionsResult {
@@ -51,21 +60,24 @@ func CarbonIntensityFactor(chain string, startDate string, endDate string, confi
 	if err != nil {
 		return response
 	}
-	req.Header.Add("Authorization", config.AuthorizationToken)
+	if config.AuthorizationToken != "" {
+		req.Header.Add("Authorization", config.AuthorizationToken)
 
-	res, err := client.Do(req)
-	if err != nil {
-		return response
-	}
-	defer res.Body.Close()
+		res, err := client.Do(req)
+		if err != nil {
+			return response
+		}
+		defer res.Body.Close()
 
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return response
-	}
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		return response
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return response
+		}
+		err = json.Unmarshal(body, &response)
+		if err != nil {
+			return response
+		}
+
 	}
 	return response
 }
@@ -80,35 +92,38 @@ func network(chain string, startDate string, endDate string, config cfg.Endpoint
 		fmt.Println(err)
 		return response
 	}
-	req.Header.Add("Authorization", config.AuthorizationToken)
+	if config.AuthorizationToken != "" {
+		req.Header.Add("Authorization", config.AuthorizationToken)
 
-	res, err := client.Do(req)
-	if err != nil {
-		fmt.Println(err)
-		return response
-	}
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		fmt.Println(err)
-		return response
-	}
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		fmt.Println(err)
-		return response
-	}
-	for i, Value := range response {
-		formatValue := strconv.FormatFloat(Value.Value, 'f', 2, 64)
-		parsedValue, err := strconv.ParseFloat(formatValue, 64)
-
+		res, err := client.Do(req)
 		if err != nil {
 			fmt.Println(err)
+			return response
 		}
+		defer res.Body.Close()
 
-		response[i].Value = parsedValue
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			fmt.Println(err)
+			return response
+		}
+		err = json.Unmarshal(body, &response)
+		if err != nil {
+			fmt.Println(err)
+			return response
+		}
+		for i, Value := range response {
+			formatValue := strconv.FormatFloat(Value.Value, 'f', 2, 64)
+			parsedValue, err := strconv.ParseFloat(formatValue, 64)
+
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			response[i].Value = parsedValue
+		}
 	}
+
 	return response
 }
 
@@ -123,34 +138,37 @@ func transaction(chain string, startDate string, endDate string, config cfg.Endp
 		fmt.Println(err)
 		return response
 	}
-	req.Header.Add("Authorization", config.AuthorizationToken)
+	if config.AuthorizationToken != "" {
+		req.Header.Add("Authorization", config.AuthorizationToken)
 
-	res, err := client.Do(req)
-	if err != nil {
-		fmt.Println(err)
-		return response
-	}
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		fmt.Println(err)
-		return response
-	}
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		fmt.Println(err)
-		return response
-	}
-	for i, Value := range response {
-		formatValue := strconv.FormatFloat(Value.Value, 'f', 2, 64)
-		parsedValue, err := strconv.ParseFloat(formatValue, 64)
-
+		res, err := client.Do(req)
 		if err != nil {
 			fmt.Println(err)
+			return response
 		}
+		defer res.Body.Close()
 
-		response[i].Value = parsedValue
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			fmt.Println(err)
+			return response
+		}
+		err = json.Unmarshal(body, &response)
+		if err != nil {
+			fmt.Println(err)
+			return response
+		}
+		for i, Value := range response {
+			formatValue := strconv.FormatFloat(Value.Value, 'f', 2, 64)
+			parsedValue, err := strconv.ParseFloat(formatValue, 64)
+
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			response[i].Value = parsedValue
+		}
 	}
+
 	return response
 }

--- a/utils/emissions.go
+++ b/utils/emissions.go
@@ -15,7 +15,7 @@ import (
 // TODO: change the variable to constant
 var chainNames = [19]string{"algorand", "avalanche", "bitcoin", "caminocolumbus", "cardano", "cosmos", "kava", "polkadot", "solana", "tezos", "tron"}
 
-func GetDailyEmissios(startDate time.Time, endDate time.Time, config cfg.EndpointService) models.Emissions {
+func GetDailyEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService) models.Emissions {
 	var dailyEmissions []models.EmissionsResult
 	startDatef := startDate.Format("2006-01-02")
 	endDatef := endDate.Format("2006-01-02")

--- a/utils/emissions.go
+++ b/utils/emissions.go
@@ -13,19 +13,29 @@ import (
 	"github.com/chain4travel/magellan/models"
 )
 
-// constant array with the chain ids in used in co2-api-inmutableinsights - if any chain id is missing just add them to the array
-var chainNames = []string{"algorand", "avalanche", "bitcoin", "caminocolumbus", "cardano", "cosmos", "ethereum", "kava", "polkadot", "solana", "tezos", "tron"}
-var columbusChainID string = chainNames[3]
+const (
+	// camino chain id used in co2-api-inmutableinsights
+	columbusChainID string = "caminocolumbus"
+	perYear         string = "Per Year"
+	perMonth        string = "Per Month"
+	perDay          string = "Per Day"
+)
+
+var countryIDs = []string{"TAIWAN", "UNITED_STATES", "GERMANY", "NETHERLANDS", "BELGIUM", "FINLAND"}
 
 func GetDailyEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) models.Emissions {
 	var dailyEmissions []models.EmissionsResult
 	startDatef := strings.Split(startDate.String(), " ")[0]
 	endDatef := strings.Split(endDate.String(), " ")[0]
 	networkName, _ := GetNetworkName(rpc)
-	for _, chain := range chainNames {
+	chainIDs, _ := AccesibleChains(config)
+	for _, chain := range chainIDs {
 		intensityFactor, err := CarbonIntensityFactor(chain, startDatef, endDatef, config)
 		if len(intensityFactor) > 0 && err == nil {
-			dailyEmissions = append(dailyEmissions, intensityFactor...)
+			dailyEmissions = append(dailyEmissions, models.EmissionsResult{
+				Chain: chain,
+				Value: GetAvgEmissionsValue(intensityFactor),
+			})
 		}
 	}
 	if dailyEmissions == nil {
@@ -37,29 +47,113 @@ func GetDailyEmissions(startDate time.Time, endDate time.Time, config cfg.Endpoi
 func GetNetworkEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) (models.Emissions, error) {
 	startDatef := strings.Split(startDate.String(), " ")[0]
 	endDatef := strings.Split(endDate.String(), " ")[0]
+	monthsBetween := int(endDate.Month() - startDate.Month())
+	yearsBetween := endDate.Year() - startDate.Year()
 	networkName, _ := GetNetworkName(rpc)
-	emissionsResult, errEmissions := network(columbusChainID, startDatef, endDatef, config)
-	if errEmissions != nil {
-		return models.Emissions{Name: fmt.Sprintf("Network Emissions %s", networkName), Value: []models.EmissionsResult{}}, errEmissions
+
+	emissions := models.Emissions{
+		Name: fmt.Sprintf("Network Emissions %s", networkName),
 	}
-	return models.Emissions{Name: fmt.Sprintf("Network Emissions %s", networkName), Value: emissionsResult}, nil
+
+	emissionsResult, errEmissions := network(columbusChainID, startDatef, endDatef, config)
+	if errEmissions != nil || emissionsResult == nil {
+		emissions.Value = []models.EmissionsResult{}
+		return emissions, errEmissions
+	}
+
+	switch {
+	// if the date range is greater than or equal to one month the values are averaged per month
+	case (monthsBetween >= 1 || monthsBetween < 0 || startDate.Year() == 1) && yearsBetween == 0:
+		emissionsPermonth, err := GetAvgEmissionsFilter(emissionsResult, false)
+		if err != nil {
+			emissions.Value = []models.EmissionsResult{}
+			return emissions, errEmissions
+		}
+		emissions.Filter = perMonth
+		emissions.Value = emissionsPermonth
+	// if the date range is greater than or equal to one year the values are averaged per year
+	case yearsBetween > 0:
+		emissionsPerYear, err := GetAvgEmissionsFilter(emissionsResult, true)
+		if err != nil {
+			emissions.Value = []models.EmissionsResult{}
+			return emissions, errEmissions
+		}
+		emissions.Filter = perYear
+		emissions.Value = emissionsPerYear
+	default:
+		emissions.Filter = perDay
+		emissions.Value = emissionsResult
+	}
+	return emissions, nil
 }
 
-func GetNetworkEmissionsPerTransaction(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) (models.Emissions, error) {
+func GetCountryEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) (models.Emissions, error) {
 	startDatef := strings.Split(startDate.String(), " ")[0]
 	endDatef := strings.Split(endDate.String(), " ")[0]
 	networkName, _ := GetNetworkName(rpc)
+	var (
+		emissionsInfo []*models.CountryEmissionsResult
+		err           error
+	)
+	for _, country := range countryIDs {
+		countryInfo, errCountry := Country(country, startDatef, endDatef, config)
+		if errCountry == nil {
+			emissionsInfo = append(emissionsInfo, &models.CountryEmissionsResult{
+				Country: country,
+				Value:   GetAvgEmissionsValue(countryInfo),
+			})
+		} else {
+			err = errCountry
+		}
+	}
+	if emissionsInfo == nil {
+		return models.Emissions{Name: fmt.Sprintf("Network Emissions Per Country %s", networkName), Value: []models.CountryEmissionsResult{}}, err
+	}
+	return models.Emissions{Name: fmt.Sprintf("Network Emissions Per Country %s", networkName), Value: emissionsInfo}, nil
+}
+func GetNetworkEmissionsPerTransaction(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) (models.Emissions, error) {
+	startDatef := strings.Split(startDate.String(), " ")[0]
+	endDatef := strings.Split(endDate.String(), " ")[0]
+	monthsBetween := int(endDate.Month() - startDate.Month())
+	yearsBetween := endDate.Year() - startDate.Year()
+	networkName, _ := GetNetworkName(rpc)
+	emissions := models.Emissions{
+		Name: fmt.Sprintf("Network Emissions per Transaction %s", networkName),
+	}
 	emissionsResult, errEmissions := transaction(columbusChainID, startDatef, endDatef, config)
-	if errEmissions != nil {
-		emissions := models.Emissions{Name: fmt.Sprintf("Network Emissions per Transaction %s", networkName), Value: []models.EmissionsResult{}}
+	if errEmissions != nil || emissionsResult == nil {
+		emissions.Value = []models.EmissionsResult{}
 		return emissions, errEmissions
 	}
-	return models.Emissions{Name: fmt.Sprintf("Network Emissions per Transaction %s", networkName), Value: emissionsResult}, nil
+	switch {
+	// if the date range is greater than or equal to one month the values are averaged per month
+	case (monthsBetween >= 1 || monthsBetween < 0 || startDate.Year() == 1) && yearsBetween == 0:
+		emissionsPermonth, err := GetAvgEmissionsFilter(emissionsResult, false)
+		if err != nil {
+			emissions.Value = []models.EmissionsResult{}
+			return emissions, errEmissions
+		}
+		emissions.Filter = perMonth
+		emissions.Value = emissionsPermonth
+	// if the date range is greater than or equal to one year the values are averaged per year
+	case yearsBetween > 0:
+		emissionsPerYear, err := GetAvgEmissionsFilter(emissionsResult, true)
+		if err != nil {
+			emissions.Value = []models.EmissionsResult{}
+			return emissions, errEmissions
+		}
+		emissions.Filter = perYear
+		emissions.Value = emissionsPerYear
+	default:
+		emissions.Filter = perDay
+		emissions.Value = emissionsResult
+	}
+	return emissions, nil
 }
 
-func CarbonIntensityFactor(chain string, startDate string, endDate string, config cfg.EndpointService) ([]models.EmissionsResult, error) {
-	var response []models.EmissionsResult
-	url := fmt.Sprintf("%s/carbon-intensity-factor?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
+func CarbonIntensityFactor(chain string, startDate string, endDate string, config cfg.EndpointService) ([]*models.EmissionsResult, error) {
+	var response []*models.EmissionsResult
+	url := fmt.Sprintf("%s/co2/carbon-intensity-factor/network?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 
@@ -87,9 +181,9 @@ func CarbonIntensityFactor(chain string, startDate string, endDate string, confi
 	return response, nil
 }
 
-func network(chain string, startDate string, endDate string, config cfg.EndpointService) ([]models.EmissionsResult, error) {
-	var response []models.EmissionsResult
-	url := fmt.Sprintf("%s/network?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
+func network(chain string, startDate string, endDate string, config cfg.EndpointService) ([]*models.EmissionsResult, error) {
+	var response []*models.EmissionsResult
+	url := fmt.Sprintf("%s/co2/network?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 
@@ -129,9 +223,9 @@ func network(chain string, startDate string, endDate string, config cfg.Endpoint
 	return response, nil
 }
 
-func transaction(chain string, startDate string, endDate string, config cfg.EndpointService) ([]models.EmissionsResult, error) {
-	var response []models.EmissionsResult
-	url := fmt.Sprintf("%s/transaction?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
+func transaction(chain string, startDate string, endDate string, config cfg.EndpointService) ([]*models.EmissionsResult, error) {
+	var response []*models.EmissionsResult
+	url := fmt.Sprintf("%s/co2/transaction?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 
@@ -168,6 +262,131 @@ func transaction(chain string, startDate string, endDate string, config cfg.Endp
 	}
 
 	return response, nil
+}
+
+func Country(country string, startDate string, endDate string, config cfg.EndpointService) ([]*models.EmissionsResult, error) {
+	var response []*models.EmissionsResult
+	url := fmt.Sprintf("%s/co2/carbon-intensity-factor/country?from=%s&to=%s&country=%s", config.URLEndpoint, startDate, endDate, country)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return response, err
+	}
+	if config.AuthorizationToken != "" {
+		req.Header.Add("Authorization", config.AuthorizationToken)
+
+		res, err := client.Do(req)
+		if err != nil {
+			return response, err
+		}
+		defer res.Body.Close()
+
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return response, err
+		}
+		err = json.Unmarshal(body, &response)
+		if err != nil {
+			return response, err
+		}
+	}
+
+	return response, nil
+}
+func AccesibleChains(config cfg.EndpointService) ([]string, error) {
+	var response []string
+	url := fmt.Sprintf("%s/misc/accessible_chains", config.URLEndpoint)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return response, err
+	}
+	if config.AuthorizationToken != "" {
+		req.Header.Add("Authorization", config.AuthorizationToken)
+
+		res, err := client.Do(req)
+		if err != nil {
+			return response, err
+		}
+		defer res.Body.Close()
+
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return response, err
+		}
+		err = json.Unmarshal(body, &response)
+		if err != nil {
+			return response, err
+		}
+	}
+
+	return response, nil
+}
+func GetAvgEmissionsValue(e []*models.EmissionsResult) float64 {
+	var Total float64
+	for _, value := range e {
+		Total += value.Value
+	}
+	Avg := Total / float64(len(e))
+	formatValue := strconv.FormatFloat(Avg, 'f', 2, 64)
+	parsedValue, err := strconv.ParseFloat(formatValue, 64)
+	if err != nil {
+		return 0.0
+	}
+	return parsedValue
+}
+func GetAvgEmissionsFilter(e []*models.EmissionsResult, perYear bool) ([]*models.EmissionsResult, error) {
+	var (
+		Total           float64
+		resultsPerMonth []*models.EmissionsResult
+		count           int
+		avg             float64
+		temporalDate    time.Time
+	)
+	date, err := stringToDate(e[0].Time)
+	if perYear {
+		temporalDate = time.Date(date.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+	} else {
+		temporalDate = time.Date(date.Year(), date.Month(), 1, 0, 0, 0, 0, time.UTC)
+	}
+
+	for id, emission := range e {
+		date, err = stringToDate(emission.Time)
+		switch {
+		case date.Month() == temporalDate.Month() && date.Year() == temporalDate.Year() && id != (len(e)-1) && !perYear:
+			Total += emission.Value
+			count++
+		case date.Year() == temporalDate.Year() && id != (len(e)-1) && perYear:
+			Total += emission.Value
+			count++
+		default:
+			avg = Total / float64(count)
+			formatValue := strconv.FormatFloat(avg, 'f', 2, 64)
+			parsedValue, _ := strconv.ParseFloat(formatValue, 64)
+			resultsPerMonth = append(resultsPerMonth, &models.EmissionsResult{
+				Time:  strings.Split(temporalDate.String(), " ")[0],
+				Chain: emission.Chain,
+				Value: parsedValue,
+			})
+			Total = emission.Value
+			count = 1
+			if perYear {
+				temporalDate = time.Date(date.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+			} else {
+				temporalDate = time.Date(date.Year(), date.Month(), 1, 0, 0, 0, 0, time.UTC)
+			}
+		}
+	}
+
+	return resultsPerMonth, err
+}
+func stringToDate(date string) (time.Time, error) {
+	// parse a string "YYYY-MM-DD" e.g. "2022-12-25" to time.Time using timeLayout "2006-01-02" predefined in
+	// go Time package
+	t, err := time.Parse("2006-01-02", date)
+	return t, err
 }
 func GetNetworkName(rpc string) (string, error) {
 	var response models.NetworkNameResponse

--- a/utils/emissions.go
+++ b/utils/emissions.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/chain4travel/magellan/cfg"
@@ -13,12 +14,13 @@ import (
 )
 
 // TODO: change the variable to constant
-var chainNames = [19]string{"algorand", "avalanche", "bitcoin", "caminocolumbus", "cardano", "cosmos", "kava", "polkadot", "solana", "tezos", "tron"}
+var chainNames = [19]string{"algorand", "avalanche", "bitcoin", "caminocolumbus", "cardano", "cosmos", "ethereum", "kava", "polkadot", "solana", "tezos", "tron"}
 
-func GetDailyEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService) models.Emissions {
+func GetDailyEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) models.Emissions {
 	var dailyEmissions []models.EmissionsResult
 	startDatef := startDate.Format("2006-01-02")
 	endDatef := endDate.Format("2006-01-02")
+	networkName := GetNetworkName(rpc)
 	for _, chain := range chainNames {
 		intensityFactor := CarbonIntensityFactor(chain, startDatef, endDatef, config)
 		if len(intensityFactor) > 0 {
@@ -26,28 +28,31 @@ func GetDailyEmissions(startDate time.Time, endDate time.Time, config cfg.Endpoi
 		}
 	}
 	if dailyEmissions == nil {
-		return models.Emissions{Name: "Daily Emissions", Value: []models.EmissionsResult{}}
+		return models.Emissions{Name: fmt.Sprintf("Daily emissions %s", networkName), Value: []models.EmissionsResult{}}
 	}
-	return models.Emissions{Name: "Daily Emissions", Value: dailyEmissions}
+	return models.Emissions{Name: fmt.Sprintf("Daily emissions %s", networkName), Value: dailyEmissions}
 }
 
-func GetNetworkEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService) models.Emissions {
+func GetNetworkEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) models.Emissions {
 	startDatef := startDate.Format("2006-01-02")
 	endDatef := endDate.Format("2006-01-02")
+	networkName := GetNetworkName(rpc)
 	emissionsResult := network(chainNames[3], startDatef, endDatef, config)
 	if emissionsResult == nil {
-		return models.Emissions{Name: "Network Emissions", Value: []models.EmissionsResult{}}
+		return models.Emissions{Name: fmt.Sprintf("Network Emissions %s", networkName), Value: []models.EmissionsResult{}}
 	}
-	return models.Emissions{Name: "Network Emissions", Value: emissionsResult}
+	return models.Emissions{Name: fmt.Sprintf("Network Emissions %s", networkName), Value: emissionsResult}
 }
-func GetNetworkEmissionsPerTransaction(startDate time.Time, endDate time.Time, config cfg.EndpointService) models.Emissions {
+
+func GetNetworkEmissionsPerTransaction(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) models.Emissions {
 	startDatef := startDate.Format("2006-01-02")
 	endDatef := endDate.Format("2006-01-02")
+	networkName := GetNetworkName(rpc)
 	emissionsResult := transaction(chainNames[3], startDatef, endDatef, config)
 	if emissionsResult == nil {
-		return models.Emissions{Name: "Network Emissions per Transaction", Value: []models.EmissionsResult{}}
+		return models.Emissions{Name: fmt.Sprintf("Network Emissions per Transaction %s", networkName), Value: []models.EmissionsResult{}}
 	}
-	return models.Emissions{Name: "Network Emissions per Transaction", Value: emissionsResult}
+	return models.Emissions{Name: fmt.Sprintf("Network Emissions per Transaction %s", networkName), Value: emissionsResult}
 }
 
 func CarbonIntensityFactor(chain string, startDate string, endDate string, config cfg.EndpointService) []models.EmissionsResult {
@@ -77,7 +82,6 @@ func CarbonIntensityFactor(chain string, startDate string, endDate string, confi
 		if err != nil {
 			return response
 		}
-
 	}
 	return response
 }
@@ -112,6 +116,7 @@ func network(chain string, startDate string, endDate string, config cfg.Endpoint
 			fmt.Println(err)
 			return response
 		}
+
 		for i, Value := range response {
 			formatValue := strconv.FormatFloat(Value.Value, 'f', 2, 64)
 			parsedValue, err := strconv.ParseFloat(formatValue, 64)
@@ -130,7 +135,6 @@ func network(chain string, startDate string, endDate string, config cfg.Endpoint
 func transaction(chain string, startDate string, endDate string, config cfg.EndpointService) []models.EmissionsResult {
 	var response []models.EmissionsResult
 	url := fmt.Sprintf("%s/transaction?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
-
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 
@@ -171,4 +175,43 @@ func transaction(chain string, startDate string, endDate string, config cfg.Endp
 	}
 
 	return response
+}
+func GetNetworkName(rpc string) string {
+	var response models.NetworkNameResponse
+	url := fmt.Sprintf("%s/ext/info", rpc)
+	payload := strings.NewReader(`{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"info.getNetworkName",
+    "params" :{
+    }
+	}`)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", url, payload)
+
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	return response.Result.NetworkName
 }


### PR DESCRIPTION
**Description:**
**1.** Four new endpoints was added to get the information about network emissions provided by immutable-insights:
          Daily emissions, network emissions, network emissions per transaction and country emissions.
         
          Network Emissions and Network Emissions per transaction have a filter to limit the results by day, month, or year 
          depending on the range of dates in the startTime and endTime in request parameter:

           If the date range is less than or equal to one month, the results will be displayed per day, if it is greater than one month 
           but less than or equal to one year, they will be displayed per month and if it is greater than one year, they will be 
           displayed per year
           
          **e.g. Per Day**
          {
              "name": "Network Emissions Camino",
              "Filter": "Per Day",
              "value": [
                {
                  "chain": "camino-columbus",
                  "time": "2022-12-01",
                  "value": 14991.42
                },
                {
                  "chain": "camino-columbus",
                  "time": "2022-12-02",
                  "value": 14991.42
                },
                {
                  "chain": "camino-columbus",
                  "time": "2022-12-03",
                  "value": 14991.42
                }
              ]
          }

         **e.g. Per month**
          {
            "name": "Network Emissions Camino",
            "Filter": "Per Month",
            "value": [
              {
                "chain": "camino-columbus",
                "time": "2022-11-01",
                "value": 13141.33
              },
              {
                "chain": "camino-columbus",
                "time": "2022-12-01",
                "value": 14991.42
              }
            ]
          }

        **e.g. Per Year**
          {
            "name": "Network Emissions Camino",
            "Filter": "Per Year",
            "value": [
              {
                "chain": "camino-columbus",
                "time": "2022-01-01",
                "value": 15168.96
              },
              {
                "chain": "camino-columbus",
                "time": "2023-01-01",
                "value": 13679.81
              }
            ]
          }

**2.** For the configuration of this endpoint, a new option was added in the services section of the config file, in which the url of the inmutableInsights service.
...
"services": {
"db": {
"dsn": "",
"driver": ""
},
"inmutableInsights": {
  "urlEndpoint":"https://co2.api.immutableinsight.io",
  "authorizationToken": ""
}
}
**Additionally an environment variable must be set in commandline with the auth token of inmutable insights api**
export authorizationTokenInmutable = "TOKEN"