### PR TITLE
[TECH-482] Co2 Emissions Service 

### DIFF
--- a/api/v2.go
+++ b/api/v2.go
@@ -118,6 +118,10 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 		Get("/addressChains", (*V2Context).AddressChains).
 		Post("/addressChains", (*V2Context).AddressChainsPost).
 		Post("/validatorsInfo", (*V2Context).ValidatorsInfo).
+		Get("/dailyEmissions", (*V2Context).DailyEmissions).
+		Get("/networkEmissions", (*V2Context).NetworkEmissions).
+		Get("/transactionEmissions", (*V2Context).TransactionEmissions).
+		Get("/countryEmissions", (*V2Context).CountryEmissions).
 
 		// List and Get routes
 		Get("/transactions", (*V2Context).ListTransactions).
@@ -165,6 +169,71 @@ func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
 		Key: c.cacheKeyForParams("geoIPValidatorsInfo", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return utils.GetValidatorsGeoIPInfo(p.RPC, &c.sc.Services.GeoIP, c.sc.Logger())
+		},
+	})
+}
+
+func (c *V2Context) DailyEmissions(w web.ResponseWriter, r *web.Request) {
+	p := &params.EmissionsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("Daily Emissions %s", p.ListParams.EndTime)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 24 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return utils.GetDailyEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode), nil
+		},
+	})
+}
+
+func (c *V2Context) CountryEmissions(w web.ResponseWriter, r *web.Request) {
+	p := &params.EmissionsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("Country Emissions %s", p.ListParams.EndTime)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 24 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return utils.GetCountryEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode)
+		},
+	})
+}
+
+func (c *V2Context) NetworkEmissions(w web.ResponseWriter, r *web.Request) {
+	p := &params.EmissionsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
+	key := fmt.Sprintf("Network Emissions %s", p.ListParams.EndTime)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 24 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return utils.GetNetworkEmissions(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode)
+		},
+	})
+}
+
+func (c *V2Context) TransactionEmissions(w web.ResponseWriter, r *web.Request) {
+	p := &params.EmissionsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("Transaction Emissions %s", p.ListParams.EndTime)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 24 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return utils.GetNetworkEmissionsPerTransaction(p.ListParams.StartTime, p.ListParams.EndTime, c.sc.Services.InmutableInsights, c.sc.ServicesCfg.CaminoNode)
 		},
 	})
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -126,6 +126,7 @@ func NewFromFile(filePath string) (*Config, error) {
 	servicesViper := newSubViper(v, keysServices)
 	servicesDBViper := newSubViper(servicesViper, keysServicesDB)
 	servicesGeoIPViper := newSubViper(servicesViper, keyServicesGeoIP)
+	servicesInmutableViper := newSubViper(servicesViper, keyServicesInmutable)
 
 	// Get chains config
 	chains, err := newChainsConfig(v)
@@ -148,6 +149,8 @@ func NewFromFile(filePath string) (*Config, error) {
 
 	urlEndpointGeoIP := servicesGeoIPViper.GetString(keyServicesEndpoint)
 	tokenGeoIP := os.Getenv(fmt.Sprintf("%sGeoIP", keyServicesToken))
+	urlEndpointInmutable := servicesInmutableViper.GetString(keyServicesEndpoint)
+	tokenInmutable := os.Getenv(fmt.Sprintf("%sInmutable", keyServicesToken))
 
 	features := v.GetStringSlice(keysFeatures)
 	featuresMap := make(map[string]struct{})
@@ -183,6 +186,10 @@ func NewFromFile(filePath string) (*Config, error) {
 			GeoIP: EndpointService{
 				URLEndpoint:        urlEndpointGeoIP,
 				AuthorizationToken: tokenGeoIP,
+			},
+			InmutableInsights: EndpointService{
+				URLEndpoint:        urlEndpointInmutable,
+				AuthorizationToken: tokenInmutable,
 			},
 		},
 		CchainID:            v.GetString(keysStreamProducerCchainID),

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -33,9 +33,10 @@ const (
 	keysServicesDBDSN    = "dsn"
 	keysServicesDBRODSN  = "ro_dsn"
 
-	keyServicesGeoIP    = "geoIP"
-	keyServicesEndpoint = "urlEndpoint"
-	keyServicesToken    = "authorizationToken"
+	keyServicesInmutable = "inmutableInsights"
+	keyServicesGeoIP     = "geoIP"
+	keyServicesEndpoint  = "urlEndpoint"
+	keyServicesToken     = "authorizationToken"
 
 	keysStreamProducerCaminoNode   = "caminoNode"
 	keysStreamProducerNodeInstance = "nodeInstance"

--- a/docker/columbus/config.json
+++ b/docker/columbus/config.json
@@ -27,8 +27,10 @@
       "driver": "mysql"
     },
     "geoIP": {
-      "urlEndpoint":"http://ip-api.com/json/",
-      "authorizationToken": ""
+      "urlEndpoint":"http://ip-api.com/json/"
+    },
+    "inmutableInsights": {
+      "urlEndpoint":"https://co2.api.immutableinsight.io"
     }
   }
 }

--- a/docker/config.json
+++ b/docker/config.json
@@ -26,8 +26,10 @@
       "driver": "mysql"
     },
     "geoIP": {
-      "urlEndpoint":"http://ip-api.com/json/",
-      "authorizationToken": ""
+      "urlEndpoint":"http://ip-api.com/json/"
+    },
+    "inmutableInsights": {
+      "urlEndpoint":"https://co2.api.immutableinsight.io"
     }
   }
 }

--- a/docker/standalone/config.standalone.json
+++ b/docker/standalone/config.standalone.json
@@ -26,8 +26,10 @@
       "driver": "mysql"
     },
     "geoIP": {
-      "urlEndpoint":"http://ip-api.com/json/",
-      "authorizationToken": ""
+      "urlEndpoint":"http://ip-api.com/json/"
+    },
+    "inmutableInsights": {
+      "urlEndpoint":"https://co2.api.immutableinsight.io"
     }
   }
 }

--- a/models/collections.go
+++ b/models/collections.go
@@ -45,6 +45,23 @@ type TransactionList struct {
 	Next *string `json:"next,omitempty"`
 }
 
+type EmissionsResult struct {
+	Chain string  `json:"chain"`
+	Time  string  `json:"time"`
+	Value float64 `json:"value"`
+}
+
+type Emissions struct {
+	Name   string      `json:"name"`
+	Filter string      `jsont:"filter"`
+	Value  interface{} `json:"value"`
+}
+
+type CountryEmissionsResult struct {
+	Country string  `json:"Country"`
+	Value   float64 `json:"Value"`
+}
+
 type CTransactionData struct {
 	Type      int       `json:"type"`
 	Block     string    `json:"block"`
@@ -244,6 +261,13 @@ type AddressChains struct {
 type AssetAggregate struct {
 	Asset     ids.ID               `json:"asset"`
 	Aggregate *AggregatesHistogram `json:"aggregate"`
+}
+
+type NetworkNameResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  struct {
+		NetworkName string `json:"networkName"`
+	} `json:"result"`
 }
 
 type IPAPIResponse struct {

--- a/services/db/migrations/050_multisig_alias_schemas.up.sql
+++ b/services/db/migrations/050_multisig_alias_schemas.up.sql
@@ -3,6 +3,7 @@
 ##
 create table multisig_aliases (
     alias           varchar(35) not null,
+    memo            varchar(256) not null,
     owner           varchar(35) not null,
     transaction_id  varchar(56) not null,
     created_at      timestamp   not null default current_timestamp,

--- a/services/db/migrations/050_multisig_alias_schemas.up.sql
+++ b/services/db/migrations/050_multisig_alias_schemas.up.sql
@@ -3,7 +3,6 @@
 ##
 create table multisig_aliases (
     alias           varchar(35) not null,
-    memo            varchar(256) not null,
     owner           varchar(35) not null,
     transaction_id  varchar(56) not null,
     created_at      timestamp   not null default current_timestamp,

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -59,6 +59,23 @@ func (p *SearchParams) CacheKey() []string {
 	return p.ListParams.CacheKey()
 }
 
+type EmissionsParams struct {
+	ListParams    ListParams
+	SubstractDays int
+}
+
+func (p *EmissionsParams) ForValues(v uint8, q url.Values) error {
+	if err := p.ListParams.ForValues(v, q); err != nil {
+		return err
+	}
+	p.SubstractDays = int(p.ListParams.EndTime.Sub(p.ListParams.StartTime).Hours()) / 24
+	return nil
+}
+
+func (p *EmissionsParams) CacheKey() []string {
+	return p.ListParams.CacheKey()
+}
+
 type TxfeeAggregateParams struct {
 	ListParams ListParams
 

--- a/utils/emissions.go
+++ b/utils/emissions.go
@@ -1,0 +1,364 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ava-labs/avalanchego/api/info"
+	"github.com/chain4travel/magellan/cfg"
+	"github.com/chain4travel/magellan/models"
+)
+
+const (
+	perYear  string = "Per Year"
+	perMonth string = "Per Month"
+	perDay   string = "Per Day"
+)
+
+var countryIDs = []string{"TAIWAN", "UNITED_STATES", "GERMANY", "NETHERLANDS", "BELGIUM", "FINLAND"}
+
+func GetDailyEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) models.Emissions {
+	dailyEmissions := []models.EmissionsResult{}
+	startDatef := strings.Split(startDate.String(), " ")[0]
+	endDatef := strings.Split(endDate.String(), " ")[0]
+	chainIDs, _ := accessibleChains(config)
+	for _, chain := range chainIDs {
+		intensityFactor, err := carbonIntensityFactor(chain, startDatef, endDatef, config)
+		if len(intensityFactor) > 0 && err == nil {
+			dailyEmissions = append(dailyEmissions, models.EmissionsResult{
+				Chain: chain,
+				Value: getAvgEmissionsValue(intensityFactor),
+			})
+		}
+	}
+	return models.Emissions{Name: "Daily emissions", Value: dailyEmissions}
+}
+
+func GetNetworkEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) (*models.Emissions, error) {
+	startDatef := strings.Split(startDate.String(), " ")[0]
+	endDatef := strings.Split(endDate.String(), " ")[0]
+	infoClient := info.NewClient(rpc)
+	networkName, _ := infoClient.GetNetworkName(context.Background())
+	emissionsResult := []*models.EmissionsResult{}
+	emissions := &models.Emissions{
+		Name:  "Network Emissions",
+		Value: emissionsResult,
+	}
+	NetworkInmutable, err := getNetworkNameInmutable(networkName, config)
+	if NetworkInmutable != "" {
+		emissionsResult, err = network(NetworkInmutable, startDatef, endDatef, config)
+		if err != nil || emissionsResult == nil {
+			return emissions, err
+		}
+		err = getEmissionsResults(emissions, emissionsResult, endDate, startDate)
+	}
+	return emissions, err
+}
+
+func GetCountryEmissions(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) (models.Emissions, error) {
+	startDatef := strings.Split(startDate.String(), " ")[0]
+	endDatef := strings.Split(endDate.String(), " ")[0]
+	infoClient := info.NewClient(rpc)
+	networkName, _ := infoClient.GetNetworkName(context.Background())
+	emissionsInfo := []*models.CountryEmissionsResult{}
+	for _, countryID := range countryIDs {
+		countryInfo, err := country(countryID, startDatef, endDatef, config)
+		if err == nil {
+			emissionsInfo = append(emissionsInfo, &models.CountryEmissionsResult{
+				Country: countryID,
+				Value:   getAvgEmissionsValue(countryInfo),
+			})
+		}
+	}
+	return models.Emissions{Name: fmt.Sprintf("Network Emissions Per Country %s", networkName), Value: emissionsInfo}, nil
+}
+func GetNetworkEmissionsPerTransaction(startDate time.Time, endDate time.Time, config cfg.EndpointService, rpc string) (*models.Emissions, error) {
+	startDatef := strings.Split(startDate.String(), " ")[0]
+	endDatef := strings.Split(endDate.String(), " ")[0]
+	infoClient := info.NewClient(rpc)
+	networkName, _ := infoClient.GetNetworkName(context.Background())
+	emissionsResult := []*models.EmissionsResult{}
+	emissions := &models.Emissions{
+		Name:  "Network Emissions Per Transaction",
+		Value: emissionsResult,
+	}
+	NetworkInmutable, err := getNetworkNameInmutable(networkName, config)
+	if NetworkInmutable != "" {
+		emissionsResult, err = transaction(NetworkInmutable, startDatef, endDatef, config)
+		if err != nil || emissionsResult == nil {
+			return emissions, err
+		}
+		err = getEmissionsResults(emissions, emissionsResult, endDate, startDate)
+	}
+	return emissions, err
+}
+
+func carbonIntensityFactor(chain string, startDate string, endDate string, config cfg.EndpointService) ([]*models.EmissionsResult, error) {
+	response := []*models.EmissionsResult{}
+	url := fmt.Sprintf("%s/co2/carbon-intensity-factor/network?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return response, err
+	}
+	req.Header.Add("Authorization", config.AuthorizationToken)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return response, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return response, err
+	}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return response, err
+	}
+
+	return response, nil
+}
+
+func network(chain string, startDate string, endDate string, config cfg.EndpointService) ([]*models.EmissionsResult, error) {
+	response := []*models.EmissionsResult{}
+	url := fmt.Sprintf("%s/co2/network?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return response, err
+	}
+	req.Header.Add("Authorization", config.AuthorizationToken)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return response, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return response, err
+	}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return response, err
+	}
+
+	for i, Value := range response {
+		formatValue := strconv.FormatFloat(Value.Value, 'f', 2, 64)
+		parsedValue, err := strconv.ParseFloat(formatValue, 64)
+
+		if err != nil {
+			continue
+		}
+
+		response[i].Value = parsedValue
+	}
+	return response, nil
+}
+
+func transaction(chain string, startDate string, endDate string, config cfg.EndpointService) ([]*models.EmissionsResult, error) {
+	response := []*models.EmissionsResult{}
+	url := fmt.Sprintf("%s/co2/transaction?chain=%s&from=%s&to=%s", config.URLEndpoint, chain, startDate, endDate)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return response, err
+	}
+	req.Header.Add("Authorization", config.AuthorizationToken)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return response, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return response, err
+	}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return response, err
+	}
+	for i, Value := range response {
+		formatValue := strconv.FormatFloat(Value.Value, 'f', 2, 64)
+		parsedValue, err := strconv.ParseFloat(formatValue, 64)
+
+		if err != nil {
+			continue
+		}
+
+		response[i].Value = parsedValue
+	}
+	return response, nil
+}
+
+func country(country string, startDate string, endDate string, config cfg.EndpointService) ([]*models.EmissionsResult, error) {
+	response := []*models.EmissionsResult{}
+	url := fmt.Sprintf("%s/co2/carbon-intensity-factor/country?from=%s&to=%s&country=%s", config.URLEndpoint, startDate, endDate, country)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return response, err
+	}
+
+	req.Header.Add("Authorization", config.AuthorizationToken)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return response, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return response, err
+	}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return response, err
+	}
+
+	return response, nil
+}
+func accessibleChains(config cfg.EndpointService) ([]string, error) {
+	response := []string{}
+	url := fmt.Sprintf("%s/misc/accessible_chains", config.URLEndpoint)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return response, err
+	}
+	req.Header.Add("Authorization", config.AuthorizationToken)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return response, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return response, err
+	}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+func getAvgEmissionsValue(e []*models.EmissionsResult) float64 {
+	var Total float64
+	for _, value := range e {
+		Total += value.Value
+	}
+	Avg := Total / float64(len(e))
+	formatValue := strconv.FormatFloat(Avg, 'f', 2, 64)
+	parsedValue, err := strconv.ParseFloat(formatValue, 64)
+	if err != nil {
+		return 0.0
+	}
+	return parsedValue
+}
+func getAvgEmissionsFilter(e []*models.EmissionsResult, perYear bool) ([]*models.EmissionsResult, error) {
+	var (
+		Total        float64
+		count        int
+		avg          float64
+		temporalDate time.Time
+	)
+	resultsPerMonth := []*models.EmissionsResult{}
+	date, err := stringToDate(e[0].Time)
+	if perYear {
+		temporalDate = time.Date(date.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+	} else {
+		temporalDate = time.Date(date.Year(), date.Month(), 1, 0, 0, 0, 0, time.UTC)
+	}
+
+	for id, emission := range e {
+		date, err = stringToDate(emission.Time)
+		switch {
+		case date.Month() == temporalDate.Month() && date.Year() == temporalDate.Year() && id != (len(e)-1) && !perYear:
+			Total += emission.Value
+			count++
+		case date.Year() == temporalDate.Year() && id != (len(e)-1) && perYear:
+			Total += emission.Value
+			count++
+		default:
+			avg = Total / float64(count)
+			formatValue := strconv.FormatFloat(avg, 'f', 2, 64)
+			parsedValue, _ := strconv.ParseFloat(formatValue, 64)
+			resultsPerMonth = append(resultsPerMonth, &models.EmissionsResult{
+				Time:  strings.Split(temporalDate.String(), " ")[0],
+				Chain: emission.Chain,
+				Value: parsedValue,
+			})
+			Total = emission.Value
+			count = 1
+			if perYear {
+				temporalDate = time.Date(date.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+			} else {
+				temporalDate = time.Date(date.Year(), date.Month(), 1, 0, 0, 0, 0, time.UTC)
+			}
+		}
+	}
+
+	return resultsPerMonth, err
+}
+func stringToDate(date string) (time.Time, error) {
+	// parse a string "YYYY-MM-DD" e.g. "2022-12-25" to time.Time using timeLayout "2006-01-02" predefined in
+	// go Time package
+	t, err := time.Parse(strings.Split(time.RFC3339, "T")[0], date)
+	return t, err
+}
+
+func getNetworkNameInmutable(networkName string, config cfg.EndpointService) (string, error) {
+	chainIDs, err := accessibleChains(config)
+	for _, chain := range chainIDs {
+		if strings.Contains(strings.ToLower(chain), strings.ToLower(networkName)) {
+			return chain, err
+		}
+	}
+	return "", err
+}
+
+func getEmissionsResults(emissions *models.Emissions, emissionsResult []*models.EmissionsResult, endDate time.Time, startDate time.Time) error {
+	monthsBetween := int(endDate.Month() - startDate.Month())
+	yearsBetween := endDate.Year() - startDate.Year()
+	switch {
+	// if the date range is greater than or equal to one month the values are averaged per month
+	case (monthsBetween >= 1 || monthsBetween < 0 || startDate.Year() == 1) && yearsBetween == 0:
+		emissionsPermonth, err := getAvgEmissionsFilter(emissionsResult, false)
+		if err != nil {
+			return err
+		}
+		emissions.Filter = perMonth
+		emissions.Value = emissionsPermonth
+	// if the date range is greater than or equal to one year the values are averaged per year
+	case yearsBetween > 0:
+		emissionsPerYear, err := getAvgEmissionsFilter(emissionsResult, true)
+		if err != nil {
+			return err
+		}
+		emissions.Filter = perYear
+		emissions.Value = emissionsPerYear
+	default:
+		emissions.Filter = perDay
+		emissions.Value = emissionsResult
+	}
+	return nil
+}


### PR DESCRIPTION
**Description:**
**1.** Four new endpoints was added to get the information about network emissions provided by immutable-insights:
Daily emissions, network emissions, network emissions per transaction and country emissions.

      Network Emissions and Network Emissions per transaction have a filter to limit the results by day, month, or year 
      depending on the range of dates in the startTime and endTime in request parameter:

       If the date range is less than or equal to one month, the results will be displayed per day, if it is greater than one month 
       but less than or equal to one year, they will be displayed per month and if it is greater than one year, they will be 
       displayed per year
       
      **e.g. Per Day**
      {
          "name": "Network Emissions Camino",
          "Filter": "Per Day",
          "value": [
            {
              "chain": "camino-columbus",
              "time": "2022-12-01",
              "value": 14991.42
            },
            {
              "chain": "camino-columbus",
              "time": "2022-12-02",
              "value": 14991.42
            },
            {
              "chain": "camino-columbus",
              "time": "2022-12-03",
              "value": 14991.42
            }
          ]
      }

     **e.g. Per month**
      {
        "name": "Network Emissions Camino",
        "Filter": "Per Month",
        "value": [
          {
            "chain": "camino-columbus",
            "time": "2022-11-01",
            "value": 13141.33
          },
          {
            "chain": "camino-columbus",
            "time": "2022-12-01",
            "value": 14991.42
          }
        ]
      }

    **e.g. Per Year**
      {
        "name": "Network Emissions Camino",
        "Filter": "Per Year",
        "value": [
          {
            "chain": "camino-columbus",
            "time": "2022-01-01",
            "value": 15168.96
          },
          {
            "chain": "camino-columbus",
            "time": "2023-01-01",
            "value": 13679.81
          }
        ]
      }
**2.** For the configuration of this endpoint, a new option was added in the services section of the config file, in which the url of the inmutableInsights service.
...
"services": {
"db": {
"dsn": "",
"driver": ""
},
"inmutableInsights": {
"urlEndpoint":"https://co2.api.immutableinsight.io",
"authorizationToken": ""
}
}
**Additionally an environment variable must be set in commandline with the auth token of inmutable insights api**
export authorizationTokenInmutable = "TOKEN"