### PR TITLE
TECH-540: Aggregations alignment 

### DIFF
--- a/docker/config.json
+++ b/docker/config.json
@@ -1,5 +1,5 @@
 {
-  "networkID": 54321,
+  "networkID": 1002,
   "metricsListenAddr": "",
   "listenAddr": ":8080",
   "features": [
@@ -7,7 +7,7 @@
   "caminoNode": "http://localhost:9650",
   "nodeInstance": "default",
   "chains": {
-    "2p7qjZY7XpF1FQmNvp8onvF4DMmwKY1aPrvajnWTq6ELtLbfCR": {
+    "2oBwpcTG6ZLViVnigvZ2MLgmz4mL2JYGR89ymRnUM6wNpN8cvq": {
       "id": "mgj786NP7uDwBCcq6YwThhaN8FLyybkCa4zBWTQbNgmK6k9A6",
       "vmType": "cvm"
     },
@@ -15,7 +15,7 @@
       "id": "11111111111111111111111111111111LpoYY",
       "vmType": "pvm"
     },
-    "2VZKJ9FTyEsN7uEegK2vdNBbmiMqafZ4SbnfHywFFQUFR2q2dr": {
+    "2hQXfgx6aeM7ZPthZJTdtUK6rG1uhdvfYqFhBw7ajziYMM7toX": {
       "id": "jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq",
       "vmType": "avm"
     }

--- a/services/indexes/pvm/writer.go
+++ b/services/indexes/pvm/writer.go
@@ -211,7 +211,7 @@ func (w *Writer) Bootstrap(ctx context.Context, conns *utils.Connections, persis
 		_, _, err := w.avax.ProcessStateOut(
 			cCtx,
 			utxo.Out,
-			ChainID,
+			utxo.TxID,
 			uint32(idx),
 			utxo.AssetID(),
 			0,
@@ -572,25 +572,10 @@ func (w *Writer) indexTransaction(ctx services.ConsumerCtx, blkID ids.ID, tx *tx
 	case *txs.CaminoAddValidatorTx:
 		innerTx := castTx.AddValidatorTx
 		baseTx = innerTx.BaseTx.BaseTx
-		outs = &avaxIndexer.AddOutsContainer{
-			Outs:    innerTx.Stake(),
-			Stake:   true,
-			ChainID: w.chainID,
-		}
 		typ = models.TransactionTypeAddValidator
 		err := w.InsertTransactionValidator(ctx, txID, innerTx.Validator)
 		if err != nil {
 			return err
-		}
-		err = w.InsertTransactionBlock(ctx, txID, blkID)
-		if err != nil {
-			return err
-		}
-		if innerTx.RewardsOwner != nil {
-			err = w.insertTransactionsRewardsOwners(ctx, txID, innerTx.RewardsOwner, baseTx, innerTx.Stake())
-			if err != nil {
-				return err
-			}
 		}
 	case *txs.DepositTx:
 		baseTx = castTx.BaseTx.BaseTx


### PR DESCRIPTION
## Description ##
This PR fixes the aggregated count of transactions shown in block explorer by taking into consideration the new camino related tx types. 

## Changes ##
- Fixed wrong values on the configuration file. 
- Fixed bug regarding duplicate outputs on `caminoAddValidatorTx`.
- Resolved bug regarding empty `txID` while parsing genesis `UTXOs`.
- Changed the way that the count aggregation is being calculated. Its calculated form the `avm_transactions` table than the `avm_outputs`. This is changed because of the following reasons: 
    - Some of the new txs types produce no outputs
    - In cross chain txs both `importTx` and `exportTx` produce outputs for the destination chain with different `txIDs` thus it was counted twice. 
