### PR TITLE
TECH-631: Atomic C-Chain txs on the cblocks query

### DIFF
--- a/services/db/migrations/020_cvm.up.sql
+++ b/services/db/migrations/020_cvm.up.sql
@@ -11,11 +11,15 @@ create table `cvm_blocks`
 
 create table `cvm_transactions_atomic`
 (
-    transaction_id varchar(50)     not null primary key,    
+    transaction_id varchar(50)     not null,
     block          decimal(65)     not null,
+    idx            bigint unsigned not null,
+    from_addr      varchar(50)     not null,
     chain_id       varchar(50)     not null,
     type           smallint        not null,
-    created_at                     timestamp not null default current_timestamp
+    serialization  mediumblob,
+    created_at     timestamp       not null default current_timestamp,
+    primary key(block,idx)
 );
 
 create table `cvm_addresses`

--- a/services/db/migrations/045_block_idx_index.down.sql
+++ b/services/db/migrations/045_block_idx_index.down.sql
@@ -1,3 +1,7 @@
 DROP INDEX cvm_transactions_txdata_block_idx on cvm_transactions_txdata;
 ALTER TABLE cvm_transactions_txdata DROP COLUMN block_idx;
 CREATE UNIQUE INDEX cvm_transactions_txdata_block ON cvm_transactions_txdata (block, idx);
+
+DROP INDEX cvm_transactions_atomic_block_idx on cvm_transactions_atomic;
+ALTER TABLE cvm_transactions_atomic DROP COLUMN block_idx;
+CREATE UNIQUE INDEX cvm_transactions_atomic_block ON cvm_transactions_atomic (block, idx);

--- a/services/db/migrations/045_block_idx_index.up.sql
+++ b/services/db/migrations/045_block_idx_index.up.sql
@@ -3,3 +3,9 @@ ALTER TABLE cvm_transactions_txdata MODIFY idx SmallInt UNSIGNED NOT NULL;
 DROP INDEX cvm_transactions_txdata_block on cvm_transactions_txdata;
 ALTER TABLE cvm_transactions_txdata ADD COLUMN block_idx BIGINT UNSIGNED GENERATED ALWAYS AS (BLOCK*1000 + cast(999 - cast(idx AS SIGNED) AS UNSIGNED)) STORED;
 CREATE UNIQUE INDEX cvm_transactions_txdata_block_idx ON cvm_transactions_txdata (block_idx);
+
+ALTER TABLE cvm_transactions_atomic MODIFY block BigInt UNSIGNED NOT NULL;
+ALTER TABLE cvm_transactions_atomic MODIFY idx SmallInt UNSIGNED NOT NULL;
+DROP INDEX cvm_transactions_atomic_block on cvm_transactions_atomic;
+ALTER TABLE cvm_transactions_atomic ADD COLUMN block_idx BIGINT UNSIGNED GENERATED ALWAYS AS (BLOCK*1000 + cast(999 - cast(idx AS SIGNED) AS UNSIGNED)) STORED;
+CREATE UNIQUE INDEX cvm_transactions_atomic_block_idx ON cvm_transactions_atomic (block_idx);


### PR DESCRIPTION
## Description ##
This PR adds the atomic c-chain txs on the c-blocks query response in order to be visible in the block explorer's c-chain view.
These txs are also taken into account by the aggregation calculations.  

## Changes ##
- Updated indexes and fields of `cvm_transactions_atomic` table, in order to be consistent with the  `cvm_transactions_txdata` table.
- Changed the way that the atomic txs are being indexed in order to contain all the appropriate data. 
- Implemented the c-blocks query in a way that it also contains the atomic-txs. 
- Updated the aggregation calculations in order to take in to consideration the atomic-txs, too.

## Example ##
Block explorer showing an import tx:

![image](https://user-images.githubusercontent.com/35269253/216291224-61260cc0-b195-41e5-979d-f4e75ffbea08.png)

## Remarks ##
By clicking the txID or the avax address (`From` or `To` address, depends on if the tx is an import or an export ones) of this tx,
we reach empty tables. For the time being these fields could become unclickable from the block explorer because this functionality is out of scope for this PR and needs further refinement. 