### PR TITLE
[GENESIS] Fix wrong UTXOId for genesis UTXOs

### DIFF
--- a/services/indexes/pvm/writer.go
+++ b/services/indexes/pvm/writer.go
@@ -202,7 +202,7 @@ func (w *Writer) Bootstrap(ctx context.Context, conns *utils.Connections, persis
 		cCtx = services.NewConsumerContext(ctx, db, int64(gc.Time), 0, persist, w.chainID)
 	)
 
-	for idx, utxo := range gc.Genesis.UTXOs {
+	for _, utxo := range gc.Genesis.UTXOs {
 		select {
 		case <-ctx.Done():
 		default:
@@ -212,7 +212,7 @@ func (w *Writer) Bootstrap(ctx context.Context, conns *utils.Connections, persis
 			cCtx,
 			utxo.Out,
 			utxo.TxID,
-			uint32(idx),
+			utxo.OutputIndex,
 			utxo.AssetID(),
 			0,
 			0,


### PR DESCRIPTION
## Fix wrong UTXOId for genesis UTXOs
Genesis UTXOs output index are wrongly set by loop index.
The PR fixes this and uses instead the real outputIndex from UTXOID.