### PR TITLE
TECH-546 Fix Multisig alias endpoint to accept and return Bech32 encoded addresses

### DIFF
--- a/api/v2.go
+++ b/api/v2.go
@@ -19,11 +19,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ava-labs/avalanchego/utils/formatting/address"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/chain4travel/magellan/caching"
 	"github.com/chain4travel/magellan/cfg"
 	"github.com/chain4travel/magellan/services/indexes/params"

--- a/db/dbmodel.go
+++ b/db/dbmodel.go
@@ -2532,6 +2532,7 @@ func (b *CvmLogs) ComputeID() {
 
 type MultisigAlias struct {
 	Alias         string
+	Bech32Address string
 	Owner         string
 	TransactionID string
 	CreatedAt     time.Time
@@ -2559,8 +2560,8 @@ func (p *persist) QueryMultisigAliasForOwner(
 	owner string) (*[]MultisigAlias, error) {
 	v := &[]MultisigAlias{}
 	_, err := session.Select(
-		"alias, owner, transaction_id, created_at",
-	).From(TableMultisigAliases).
+		"alias, bech32_address, owner, transaction_id, created_at",
+	).From(TableMultisigAliases).Join(TableAddressBech32, "alias=address").
 		Where("owner=?", owner).
 		LoadContext(ctx, v)
 	return v, err

--- a/db/dbmodel_test.go
+++ b/db/dbmodel_test.go
@@ -1543,6 +1543,7 @@ func TestInsertMultisigAlias(t *testing.T) {
 	v := &MultisigAlias{}
 	v.Alias = "abcdefghijklmnopqrstABCDEF1234567"
 	v.Owner = "ABCDEFghijklmnopqrstabcdef1234567"
+	v.Bech32Address = "kopernikus1vscyf7czawylztn6ghhg0z27swwewxgzgpcxvy"
 	v.TransactionID = "abcdefghijklmnopqrstABCDEF1234567abcdefghijklmnop"
 	v.CreatedAt = time.Now().UTC().Truncate(1 * time.Second)
 
@@ -1550,6 +1551,11 @@ func TestInsertMultisigAlias(t *testing.T) {
 	if err != nil {
 		t.Fatal("insert fail", err)
 	}
+	err = p.InsertAddressBech32(ctx, rawDBConn.NewSession(stream), &AddressBech32{Address: v.Alias, Bech32Address: "kopernikus1vscyf7czawylztn6ghhg0z27swwewxgzgpcxvy", UpdatedAt: time.Now().UTC().Truncate(1 * time.Second)}, false)
+	if err != nil {
+		t.Fatal("insert address bech32 fail", err)
+	}
+
 	fv, err := p.QueryMultisigAliasForOwner(ctx, rawDBConn.NewSession(stream), v.Owner)
 	if err != nil {
 		t.Fatal("query fail", err)

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -225,7 +225,7 @@ func (r *Reader) GetMultisigAlias(ctx context.Context, ownerAddress string) (*mo
 
 	aliasList := make([]string, 0, len(*alias))
 	for _, v := range *alias {
-		aliasList = append(aliasList, v.Alias)
+		aliasList = append(aliasList, v.Bech32Address)
 	}
 
 	multisigAliasList := &models.MultisigAliasList{Alias: aliasList}


### PR DESCRIPTION
## Description ##
This PR updates the multisig alias endpoint to accept and return bech32 encoded addresses instead of the cb58 addresses used before internally in Magellan. We now make use of the db table addresses_bech32 that holds a map between cb58 addresses and their bech32 encoded counterpart.

## Changes ##
- MultisigAlias struct holds the Bech32Address retrieved from the addresses_bech32 table
- QueryMultisigAliasForOwner method updated to perform a join with addresses_bech32 table instead of a separate select statement for each multisig alias queried.
- Updated test

## Example ##
Calling the endpoint with `C-kopernikus1w3szy4e5excad4j8xp2ua0ukqcfq2uh4qn4sgc` will return an array of the multisig alias that the address is owner of.
![image](https://user-images.githubusercontent.com/7500237/217486929-00ee86dd-7e42-4567-99bc-a4240208721e.png)

