### PR TITLE
[TECH-699] Change In Validators Info Configuration

### DIFF
--- a/api/v2.go
+++ b/api/v2.go
@@ -161,7 +161,6 @@ func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
 	}
 
 	c.WriteCacheable(w, caching.Cacheable{
-		TTL: 24 * time.Hour,
 		Key: c.cacheKeyForParams("geoIPValidatorsInfo", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return utils.GetValidatorsGeoIPInfo(p.RPC, &c.sc.Services.GeoIP, c.sc.Logger())

--- a/utils/validator_info.go
+++ b/utils/validator_info.go
@@ -103,7 +103,7 @@ func setGeoIPInfo(validatorInfo *models.Validator, peerIP string, config *cfg.En
 func GetLocationByIP(ip string, config *cfg.EndpointService) (models.IPAPIResponse, error) {
 	var response models.IPAPIResponse
 	ip = strings.Split(ip, ":")[0]
-	url := fmt.Sprintf("%s%s", config.URLEndpoint, ip)
+	url := fmt.Sprintf("%s%s?key=%s", config.URLEndpoint, ip, config.AuthorizationToken)
 	// Perform the HTTP GET request
 	client := &http.Client{}
 


### PR DESCRIPTION
Removed the TTL from the ValidatorsInfo endpoint and added the "key" query parameter to the request send to IP-API endpoint.
To configure the endpoint with the new credentials, you must add the endpoint url in the config.json services used to run the api in magellan:
...
 "services": {
      "db": {
        "dsn": "root:password@/magellan",
        "driver": "mysql"
      },
      **"geoIP": {
        "urlEndpoint":"https://pro.ip-api.com/json/"
      }**
    }
...
**Additionally an environment variable must be set in commandline with the auth token of IP-API
export authorizationTokenGeoIP="TOKEN"**