### PR TITLE
Added endpoint to get all owners of a multisig alias

### DIFF
--- a/db/dbmodel.go
+++ b/db/dbmodel.go
@@ -477,6 +477,12 @@ type Persist interface {
 		dbr.SessionRunner,
 		string,
 	) error
+
+	QueryMultisigOwnersForAlias(
+		context.Context,
+		dbr.SessionRunner,
+		string,
+	) (*[]string, error)
 }
 
 type persist struct{}
@@ -2578,4 +2584,17 @@ func (p *persist) DeleteMultisigAlias(
 		return EventErr(TableMultisigAliases, false, err)
 	}
 	return nil
+}
+
+func (p *persist) QueryMultisigOwnersForAlias(
+	ctx context.Context,
+	session dbr.SessionRunner,
+	alias string) (*[]string, error) {
+	v := &[]string{}
+
+	_, err := session.Select("bech32_address").
+		From(TableMultisigAliases).Join(TableAddressBech32, "owner=address").
+		Where("alias=?", alias).
+		LoadContext(ctx, v)
+	return v, err
 }

--- a/db/dbmodel_mock.go
+++ b/db/dbmodel_mock.go
@@ -725,3 +725,12 @@ func (m *MockPersist) DeleteMultisigAlias(ctx context.Context, runner dbr.Sessio
 	delete(m.MultisigAlias, s)
 	return nil
 }
+
+func (m *MockPersist) QueryMultisigOwnersForAlias(ctx context.Context, runner dbr.SessionRunner, s string) (*[]string, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if v, present := m.MultisigAlias[s]; present {
+		return &[]string{v.Owner}, nil
+	}
+	return nil, nil
+}

--- a/db/dbmodel_test.go
+++ b/db/dbmodel_test.go
@@ -1529,7 +1529,7 @@ func TestNodeIndex(t *testing.T) {
 	}
 }
 
-func TestInsertMultisigAlias(t *testing.T) {
+func TestMultisigAlias(t *testing.T) {
 	p := NewPersist()
 	ctx := context.Background()
 	stream := &dbr.NullEventReceiver{}
@@ -1541,10 +1541,10 @@ func TestInsertMultisigAlias(t *testing.T) {
 	_, _ = rawDBConn.NewSession(stream).DeleteFrom(TableMultisigAliases).Exec()
 
 	v := &MultisigAlias{}
-	v.Alias = "abcdefghijklmnopqrstABCDEF1234567"
-	v.Owner = "ABCDEFghijklmnopqrstabcdef1234567"
+	v.Alias = "58xVinwm6Kg5Z3bfn3yxJVx7bJTzMgyJg"
+	v.Owner = "68Z2EEfb2Sp1hFT8Xpsp7kEFE5Mdaaj42"
 	v.Memo = "Memo"
-	v.Bech32Address = "kopernikus1vscyf7czawylztn6ghhg0z27swwewxgzgpcxvy"
+	v.Bech32Address = "kopernikus194sm66h2qrmtae7gcesnmxdstzqv0mpt53yjft"
 	v.TransactionID = "abcdefghijklmnopqrstABCDEF1234567abcdefghijklmnop"
 	v.CreatedAt = time.Now().UTC().Truncate(1 * time.Second)
 
@@ -1552,7 +1552,7 @@ func TestInsertMultisigAlias(t *testing.T) {
 	if err != nil {
 		t.Fatal("insert fail", err)
 	}
-	err = p.InsertAddressBech32(ctx, rawDBConn.NewSession(stream), &AddressBech32{Address: v.Alias, Bech32Address: "kopernikus1vscyf7czawylztn6ghhg0z27swwewxgzgpcxvy", UpdatedAt: time.Now().UTC().Truncate(1 * time.Second)}, false)
+	err = p.InsertAddressBech32(ctx, rawDBConn.NewSession(stream), &AddressBech32{Address: v.Alias, Bech32Address: "kopernikus194sm66h2qrmtae7gcesnmxdstzqv0mpt53yjft", UpdatedAt: time.Now().UTC().Truncate(1 * time.Second)}, false)
 	if err != nil {
 		t.Fatal("insert address bech32 fail", err)
 	}
@@ -1564,6 +1564,21 @@ func TestInsertMultisigAlias(t *testing.T) {
 	if !reflect.DeepEqual(*v, (*fv)[0]) {
 		t.Fatal("compare fail")
 	}
+
+	ownerBech32Addr := "kopernikus18pry238vq8uzzpar32wa4x4p2rkyc7wx2qnctc"
+	err = p.InsertAddressBech32(ctx, rawDBConn.NewSession(stream), &AddressBech32{Address: v.Owner, Bech32Address: ownerBech32Addr, UpdatedAt: time.Now().UTC().Truncate(1 * time.Second)}, false)
+	if err != nil {
+		t.Fatal("insert address bech32 fail", err)
+	}
+
+	owners, err := p.QueryMultisigOwnersForAlias(ctx, rawDBConn.NewSession(stream), v.Alias)
+	if err != nil {
+		t.Fatal("query fail", err)
+	}
+	if !reflect.DeepEqual(ownerBech32Addr, (*owners)[0]) {
+		t.Fatal("compare fail")
+	}
+
 	err = p.DeleteMultisigAlias(ctx, rawDBConn.NewSession(stream), v.Alias)
 	if err != nil {
 		t.Fatal("delete fail", err)

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -233,6 +233,20 @@ func (r *Reader) GetMultisigAlias(ctx context.Context, ownerAddress string) (*mo
 	return multisigAliasList, err
 }
 
+func (r *Reader) GetOwnersForMultisigAlias(ctx context.Context, aliasAddress string) (*[]string, error) {
+	dbRunner, err := r.conns.DB().NewSession("multisig_alias_owners", cfg.RequestTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	owners, err := r.sc.Persist.QueryMultisigOwnersForAlias(ctx, dbRunner, aliasAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return owners, nil
+}
+
 func (r *Reader) ListAddresses(ctx context.Context, p *params.ListAddressesParams) (*models.AddressList, error) {
 	dbRunner, err := r.conns.DB().NewSession("list_addresses", cfg.RequestTimeout)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR adds another endpoint for getting the owners of a multisig alias. By passing the bech32 alias address we get an array of owner addresses. The endpoint is reachable at 

**http://localhost:8080/v2/multisigalias/alias/:alias**

where **:alias** the bech32 encoded alias address

The response is an array of bech32 encoded owner addresses.

## Changes
- Added endpoint to get all owner of a multisig alias
- Updated multisig tests

## Example

Calling the endpoint with X-kopernikus194sm66h2qrmtae7gcesnmxdstzqv0mpt53yjft will return an array of the owner address for that alias.
![image](https://user-images.githubusercontent.com/7500237/221200659-e2db18f6-0b86-4585-974d-2c339d1613eb.png)
