### PR TITLE
Get multisig alias endpoint can support list of owners

### DIFF
--- a/db/dbmodel.go
+++ b/db/dbmodel.go
@@ -466,10 +466,10 @@ type Persist interface {
 		*MultisigAlias,
 	) error
 
-	QueryMultisigAliasForOwner(
+	QueryMultisigAliasesForOwners(
 		context.Context,
 		dbr.SessionRunner,
-		string,
+		[]string,
 	) (*[]MultisigAlias, error)
 
 	DeleteMultisigAlias(
@@ -2556,15 +2556,16 @@ func (p *persist) InsertMultisigAlias(ctx context.Context, session dbr.SessionRu
 	return nil
 }
 
-func (p *persist) QueryMultisigAliasForOwner(
+func (p *persist) QueryMultisigAliasesForOwners(
 	ctx context.Context,
 	session dbr.SessionRunner,
-	owner string) (*[]MultisigAlias, error) {
+	owners []string) (*[]MultisigAlias, error) {
 	v := &[]MultisigAlias{}
 	_, err := session.Select(
-		"alias, memo, bech32_address, owner, transaction_id, created_at",
+		"bech32_address",
 	).From(TableMultisigAliases).Join(TableAddressBech32, "alias=address").
-		Where("owner=?", owner).
+		Where("owner IN ?", owners).
+		GroupBy("alias").
 		LoadContext(ctx, v)
 	return v, err
 }

--- a/db/dbmodel_mock.go
+++ b/db/dbmodel_mock.go
@@ -710,11 +710,11 @@ func (m *MockPersist) InsertMultisigAlias(ctx context.Context, runner dbr.Sessio
 	return nil
 }
 
-func (m *MockPersist) QueryMultisigAliasForOwner(ctx context.Context, runner dbr.SessionRunner, v string) (*[]MultisigAlias, error) {
+func (m *MockPersist) QueryMultisigAliasesForOwners(ctx context.Context, runner dbr.SessionRunner, v []string) (*[]MultisigAlias, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	if v, present := m.MultisigAlias[v]; present {
-		return &[]MultisigAlias{{Owner: v.Owner}}, nil
+	if v, present := m.MultisigAlias[v[0]]; present {
+		return &[]MultisigAlias{{Bech32Address: v.Bech32Address}}, nil
 	}
 	return nil, nil
 }

--- a/db/dbmodel_test.go
+++ b/db/dbmodel_test.go
@@ -1557,11 +1557,12 @@ func TestInsertMultisigAlias(t *testing.T) {
 		t.Fatal("insert address bech32 fail", err)
 	}
 
-	fv, err := p.QueryMultisigAliasForOwner(ctx, rawDBConn.NewSession(stream), v.Owner)
+	owners := []string{v.Owner}
+	fv, err := p.QueryMultisigAliasesForOwners(ctx, rawDBConn.NewSession(stream), owners)
 	if err != nil {
 		t.Fatal("query fail", err)
 	}
-	if !reflect.DeepEqual(*v, (*fv)[0]) {
+	if !reflect.DeepEqual(v.Bech32Address, (*fv)[0].Bech32Address) {
 		t.Fatal("compare fail")
 	}
 	err = p.DeleteMultisigAlias(ctx, rawDBConn.NewSession(stream), v.Alias)

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -215,13 +215,13 @@ func (r *Reader) Aggregate(aggregateCache caching.AggregatesCache, params *param
 	}, nil
 }
 
-func (r *Reader) GetMultisigAlias(ctx context.Context, ownerAddress string) (*models.MultisigAliasList, error) {
+func (r *Reader) GetMultisigAlias(ctx context.Context, ownersAddresses []string) (*models.MultisigAliasList, error) {
 	dbRunner, err := r.conns.DB().NewSession("multisig_alias", cfg.RequestTimeout)
 	if err != nil {
 		return nil, err
 	}
 
-	alias, err := r.sc.Persist.QueryMultisigAliasForOwner(ctx, dbRunner, ownerAddress)
+	alias, err := r.sc.Persist.QueryMultisigAliasesForOwners(ctx, dbRunner, ownersAddresses)
 
 	aliasList := make([]string, 0, len(*alias))
 	for _, v := range *alias {


### PR DESCRIPTION
### Description
This PR modifies the existing api endpoint for getting the multisig alias for an owner address to accept a list of owner addresses. This will return a list of all multisig aliases for the addresses passed in the query.

### Example 
In the following example we pass 3 owner addresses, separated by comma, as url params (**X-kopernikus18pry238vq8uzzpar32wa4x4p2rkyc7wx2qnctc** **X-kopernikus1qfyvkqnv8yd9rmlf6sv0gdx20dgg4erslxurav** **X-kopernikus18pry238vq8uzzpar32wa4x4p2rkyc7wx2qnctc**)
![image](https://user-images.githubusercontent.com/7500237/223473965-63fab14e-f24b-4bc0-85e8-9f2facdade8a.png)
The result is a list of all multisig aliases that these owners take part in.