### PR TITLE
Blockchain statistics endpoint

### DIFF
--- a/api/v2.go
+++ b/api/v2.go
@@ -120,6 +120,13 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 		Get("/addressChains", (*V2Context).AddressChains).
 		Post("/addressChains", (*V2Context).AddressChainsPost).
 		Post("/validatorsInfo", (*V2Context).ValidatorsInfo).
+		Get("/activeAddresses", (*V2Context).ActiveAddresses).
+		Get("/uniqueAddresses", (*V2Context).UniqueAddresses).
+		Get("/averageBlockSize", (*V2Context).AverageBlockSize).
+		Get("/dailyTransactions", (*V2Context).DailyTransactions).
+		Get("/dailyGasUsed", (*V2Context).DailyGasUsed).
+		Get("/avgGasPriceUsed", (*V2Context).AvgGasPriceUsed).
+		Get("/dailyTokenTransfer", (*V2Context).DailyTokenTransfer).
 		Get("/dailyEmissions", (*V2Context).DailyEmissions).
 		Get("/networkEmissions", (*V2Context).NetworkEmissions).
 		Get("/transactionEmissions", (*V2Context).TransactionEmissions).
@@ -170,6 +177,188 @@ func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
 		Key: c.cacheKeyForParams("geoIPValidatorsInfo", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return utils.GetValidatorsGeoIPInfo(p.RPC, &c.sc.Services.GeoIP, c.sc.Logger())
+		},
+	})
+}
+
+func (c *V2Context) ActiveAddresses(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams("activeAddresses", p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.ActiveAddresses(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) UniqueAddresses(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams("uniqueAddresses", p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.UniqueAddresses(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) AverageBlockSize(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams("AverageBlockSize", p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.AverageBlockSizeReader(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) DailyTransactions(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("dailyTransactionsChart %s", p.ListParams.ID)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.DailyTransactions(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) DailyGasUsed(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("DailyGasUsed %s", p.ListParams.ID)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.GasUsedPerDay(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) AvgGasPriceUsed(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("AvgGasPriceUsed %s", p.ListParams.ID)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.AvgGasPriceUsed(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) DailyTokenTransfer(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("DailyTokenTransfer %s", p.ListParams.ID)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.DailyTokenTransfer(ctx, &p.ListParams)
 		},
 	})
 }

--- a/caching/aggregates_cache.go
+++ b/caching/aggregates_cache.go
@@ -29,6 +29,7 @@ type AggregatesCache interface {
 	InitCacheStorage(cfg.Chains)
 	GetAggregatesFeesAndUpdate(map[string]cfg.Chain, *utils.Connections, string, time.Time, time.Time, string) error
 	GetAggregatesAndUpdate(map[string]cfg.Chain, *utils.Connections, string, time.Time, time.Time, string) error
+	UpdateStatisticsCache(*utils.Connections) error
 }
 
 type aggregatesCache struct {
@@ -450,6 +451,15 @@ func (ac *aggregatesCache) GetAggregatesFeesAndUpdate(chains map[string]cfg.Chai
 	}
 	ac.aggregateFeesMap[chainid][rangeKeyType] = aggs.TxfeeAggregates.Txfee
 	return nil
+}
+
+func (ac *aggregatesCache) UpdateStatisticsCache(conns *utils.Connections) error {
+	dbRunner, err := conns.DB().NewSession("update_statistics_cache", cfg.RequestTimeout)
+	if err != nil {
+		return err
+	}
+	_, err = dbRunner.Exec("Call daily_statistics_update()")
+	return err
 }
 
 func getFirstTransactionTime(conns *utils.Connections, chainIDs []string) (time.Time, error) {

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -65,18 +65,19 @@ type AggregatesFeesMain struct {
 }
 
 type Config struct {
-	NetworkID           uint32 `json:"networkID"`
-	Chains              `json:"chains"`
-	Services            `json:"services"`
-	MetricsListenAddr   string `json:"metricsListenAddr"`
-	AdminListenAddr     string `json:"adminListenAddr"`
-	Features            map[string]struct{}
-	CchainID            string `json:"cchainId"`
-	CaminoNode          string `json:"caminoNode"`
-	NodeInstance        string `json:"nodeInstance"`
-	CacheUpdateInterval uint64 `json:"cacheUpdateInterval"`
-	AP5Activation       uint64 `json:"ap5Activation"`
-	BanffActivation     uint64 `json:"banffActivation"`
+	NetworkID               uint32 `json:"networkID"`
+	Chains                  `json:"chains"`
+	Services                `json:"services"`
+	MetricsListenAddr       string `json:"metricsListenAddr"`
+	AdminListenAddr         string `json:"adminListenAddr"`
+	Features                map[string]struct{}
+	CchainID                string `json:"cchainId"`
+	CaminoNode              string `json:"caminoNode"`
+	NodeInstance            string `json:"nodeInstance"`
+	CacheUpdateInterval     uint64 `json:"cacheUpdateInterval"`
+	CacheStatisticsInterval uint64 `json:"cacheStatisticsInterval"`
+	AP5Activation           uint64 `json:"ap5Activation"`
+	BanffActivation         uint64 `json:"banffActivation"`
 }
 
 type Chain struct {
@@ -192,11 +193,12 @@ func NewFromFile(filePath string) (*Config, error) {
 				AuthorizationToken: tokenInmutable,
 			},
 		},
-		CchainID:            v.GetString(keysStreamProducerCchainID),
-		CaminoNode:          v.GetString(keysStreamProducerCaminoNode),
-		NodeInstance:        v.GetString(keysStreamProducerNodeInstance),
-		CacheUpdateInterval: uint64(v.GetInt(keysCacheUpdateInterval)),
-		AP5Activation:       uint64(ap5Activation),
-		BanffActivation:     uint64(banffActivation),
+		CchainID:                v.GetString(keysStreamProducerCchainID),
+		CaminoNode:              v.GetString(keysStreamProducerCaminoNode),
+		NodeInstance:            v.GetString(keysStreamProducerNodeInstance),
+		CacheUpdateInterval:     uint64(v.GetInt(keysCacheUpdateInterval)),
+		CacheStatisticsInterval: uint64(v.GetInt(keysCacheStatisticsInterval)),
+		AP5Activation:           uint64(ap5Activation),
+		BanffActivation:         uint64(banffActivation),
 	}, nil
 }

--- a/cfg/defaults.go
+++ b/cfg/defaults.go
@@ -16,6 +16,7 @@ package cfg
 const defaultJSON = `{
   "networkID": 1001,
   "cacheUpdateInterval": "5",
+  "cacheStatisticsInterval": "1",
   "logDirectory": "/tmp/magellan/logs",
   "listenAddr": ":8080",
   "chains": {},

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -43,5 +43,6 @@ const (
 
 	keysStreamProducerCchainID = "cchainID"
 
-	keysCacheUpdateInterval = "cacheUpdateInterval"
+	keysCacheUpdateInterval     = "cacheUpdateInterval"
+	keysCacheStatisticsInterval = "cacheStatisticsInterval"
 )

--- a/cmds/magelland/magelland.go
+++ b/cmds/magelland/magelland.go
@@ -212,6 +212,12 @@ func createAPICmds(sc *servicesctrl.Control, config *cfg.Config, runErr *error) 
 					return
 				}
 			}()
+			go func() {
+				err := sc.StartStatisticsScheduler(config)
+				if err != nil {
+					return
+				}
+			}()
 			lc, err := api.NewServer(sc, *config)
 			if err != nil {
 				*runErr = err

--- a/db/dbmodel.go
+++ b/db/dbmodel.go
@@ -1097,6 +1097,7 @@ type CvmBlocks struct {
 	CreatedAt     time.Time
 	Proposer      string
 	ProposerTime  *time.Time
+	Size          float64
 }
 
 func (p *persist) QueryCvmBlock(
@@ -1128,8 +1129,8 @@ func (p *persist) InsertCvmBlocks(
 ) error {
 	var err error
 	_, err = sess.
-		InsertBySql("insert into "+TableCvmBlocks+" (block,hash,chain_id,evm_tx,atomic_tx,serialization,created_at, proposer,proposer_time) values("+v.Block+",?,?,?,?,?,?,?,?)",
-			v.Hash, v.ChainID, v.EvmTx, v.AtomicTx, v.Serialization, v.CreatedAt, v.Proposer, v.ProposerTime).
+		InsertBySql("insert into "+TableCvmBlocks+" (block,hash,chain_id,evm_tx,atomic_tx,serialization,created_at, proposer,proposer_time,size) values("+v.Block+",?,?,?,?,?,?,?,?,?)",
+			v.Hash, v.ChainID, v.EvmTx, v.AtomicTx, v.Serialization, v.CreatedAt, v.Proposer, v.ProposerTime, v.Size).
 		ExecContext(ctx)
 	if err != nil && !utils.ErrIsDuplicateEntryError(err) {
 		return EventErr(TableCvmBlocks, false, err)

--- a/models/collections.go
+++ b/models/collections.go
@@ -153,6 +153,59 @@ type CResult struct {
 	Hash   string `json:"hash"`
 }
 
+type StatisticsStruct struct {
+	HighestNumber float64     `json:"highestValue"`
+	HighestDate   string      `json:"highestDate"`
+	LowestNumber  float64     `json:"lowerValue"`
+	LowestDate    string      `json:"lowerDate"`
+	TxInfo        interface{} `json:"txInfo"`
+}
+
+type TransactionsInfo struct {
+	Date              string  `json:"date"`
+	TotalTransactions int     `json:"totalTransactions"`
+	AvgBlockTime      float32 `json:"avgBlockTime"`
+	AvgBlockSize      float32 `json:"avgBlockSize"`
+	TotalBlockCount   int     `json:"totalBlockCount"`
+	TotalUnclesCount  int     `json:"totalUnclesCount"`
+	NewAddressSeen    string  `json:"newAddressSeen"`
+}
+
+type TransactionsPerDate struct {
+	Counter float64 `json:"counter"`
+	DateAt  string  `json:"dateAt"`
+}
+
+type GasUsedPerDate struct {
+	Gas  float32 `json:"avgGas"`
+	Date string  `json:"date"`
+}
+
+type AverageBlockSize struct {
+	BlockSize float64 `json:"blockSize"`
+	DateInfo  string  `json:"dateInfo"`
+}
+
+type AddressStruct struct {
+	HighestNumber int         `json:"highestValue"`
+	HighestDate   string      `json:"highestDate"`
+	LowestNumber  int         `json:"lowestValue"`
+	LowestDate    string      `json:"lowestDate"`
+	AddressInfo   interface{} `json:"addressInfo"`
+}
+type UniqueAddresses struct {
+	TotalAddresses int    `json:"totalAddresses"`
+	DateAt         string `json:"dateAt"`
+	DailyIncrease  int    `json:"dailyIncrease"`
+}
+
+type ActiveAddresses struct {
+	Total        int    `json:"total"`
+	ReceiveCount int    `json:"receiveCount"`
+	SendCount    int    `json:"sendCount"`
+	DateAt       string `json:"dateAt"`
+}
+
 // SearchResults represents a set of items returned for a search query.
 type SearchResults struct {
 	// Count is the total number of matching results

--- a/services/db/migrations/051_add_block_size.down.sql
+++ b/services/db/migrations/051_add_block_size.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cmv_blocks DROP COLUMN size;

--- a/services/db/migrations/051_add_block_size.up.sql
+++ b/services/db/migrations/051_add_block_size.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cvm_blocks ADD COLUMN `size` FLOAT default 0 AFTER `proposer_time`;

--- a/services/db/migrations/052_create_info_schema.down.sql
+++ b/services/db/migrations/052_create_info_schema.down.sql
@@ -1,0 +1,1 @@
+drop table statistics;

--- a/services/db/migrations/052_create_info_schema.up.sql
+++ b/services/db/migrations/052_create_info_schema.up.sql
@@ -1,0 +1,119 @@
+-- magellan.Test definition
+
+CREATE TABLE `statistics` (
+  `date_at` date NOT NULL,
+  `cvm_tx` int DEFAULT NULL,
+  `avm_tx` int DEFAULT NULL,
+  `token_transfer` float DEFAULT NULL,
+  `gas_used` float DEFAULT NULL,
+  `receive_count` int DEFAULT NULL,
+  `send_count` int DEFAULT NULL,
+  `active_accounts` int DEFAULT NULL,
+  `gas_price` float DEFAULT NULL,
+  `blocks` int DEFAULT NULL,
+  `avg_block_size`float DEFAULT NULL,
+  PRIMARY KEY (`date_at`)
+);
+
+CREATE PROCEDURE `daily_statistics_update`()
+BEGIN
+DECLARE v_created_at DATE;
+DECLARE v_cvm_tx INTEGER;
+DECLARE v_avm_tx INTEGER;
+DECLARE v_receive_count INTEGER;
+DECLARE v_send_count INTEGER;
+DECLARE v_active_accounts INTEGER;
+DECLARE v_token_transfer FLOAT;
+DECLARE v_gas_used FLOAT;
+DECLARE v_gas_price FLOAT;
+DECLARE v_blocks INTEGER;
+DECLARE v_avg_block_size FLOAT;
+
+-- 1. create a cursor to save the results of date, cvm tx count, avm tx count, addresses send count, addresses receive count,
+--    total token transfer, total gas price, total gas used, avg block size, blocks count... using a full join between
+--    cvm_transactions_txdata, avm_transactions and cvm_blocks
+DECLARE cur1 CURSOR FOR WITH cvm_transaction_results AS (
+    SELECT DATE(created_at) as date_at, COUNT(*) as cvm_tx, COUNT(DISTINCT id_to_addr) receive_count, 
+    COUNT(DISTINCT id_from_addr) send_count, SUM(amount) as token_transfer, SUM(gas_used) as gas_used, SUM(gas_price) as gas_price,
+    COUNT(DISTINCT block_idx) as blocks
+    FROM cvm_transactions_txdata ctt 
+    WHERE DATE(created_at) >= @max_date
+    GROUP BY DATE(created_at)
+    ),
+    avm_transaction_results AS (
+        SELECT DATE(created_at) as date_at_avm, COUNT(*) as avm_tx
+        FROM avm_transactions at2 
+        WHERE DATE(created_at) >= @max_date
+        GROUP BY DATE(created_at)
+    ),
+    cvm_blocks_results AS (
+        SELECT DATE(created_at) as date_at_blocks, AVG(size) as avg_size
+        FROM cvm_blocks cb
+        WHERE DATE(created_at) >= @max_date
+        GROUP BY DATE(created_at)
+    )
+    SELECT *
+    FROM (
+        SELECT t1.cvm_tx, t1.date_at, t1.token_transfer, t1.gas_used, t1.receive_count, t1.send_count, GREATEST(t1.receive_count, t1.send_count), t1.gas_price, t1.blocks, t2.avm_tx, t3.avg_size
+        FROM cvm_transaction_results t1
+        LEFT JOIN avm_transaction_results t2 ON t1.date_at = t2.date_at_avm
+        LEFT JOIN cvm_blocks_results t3 ON t1.date_at = t3.date_at_blocks
+        UNION
+        SELECT t1.cvm_tx, t2.date_at_avm as date_at, t1.token_transfer, t1.gas_used,t1.receive_count, t1.send_count,GREATEST(t1.receive_count, t1.send_count), t1.gas_price, t1.blocks, t2.avm_tx, t3.avg_size
+        FROM avm_transaction_results t2
+        LEFT JOIN cvm_transaction_results t1 ON t2.date_at_avm = t1.date_at
+        LEFT JOIN cvm_blocks_results t3 ON t2.date_at_avm = t3.date_at_blocks
+    ) as results;
+
+ -- 2. Error control in case that the statistics table not exists.
+CREATE TABLE IF NOT EXISTS statistics (
+    date_at DATE,
+    cvm_tx INT,
+    avm_tx INT,
+    receive_count INT,
+    send_count INT,
+    gas_price INT,
+    blocks INT,
+    token_transfer FLOAT,
+    gas_used FLOAT,
+    gas_price FLOAT,
+    avg_block_size FLOAT,
+    PRIMARY KEY (date_at)
+   );
+
+-- 3. Search the max date in statistics table used as condition in the cursor
+  SELECT
+	MAX(date_at)
+INTO
+	@max_date
+FROM
+	statistics;
+
+-- 3.1 if the table test is empty, set the max date for default with 0000-00-00
+  IF @max_date IS NULL THEN
+    SET @max_date = '1000-01-01';
+  END IF;
+
+  OPEN cur1;
+  FETCH cur1 INTO v_cvm_tx,v_created_at,v_token_transfer, v_gas_used, v_receive_count, v_send_count, v_active_accounts,v_gas_price, v_blocks, v_avm_tx, v_avg_block_size;
+-- 4. Insert or update the data in statistics table
+  WHILE (v_created_at IS NOT NULL) DO
+  
+  -- 4.1 if the current date in v_created_at is equal to another value in the table statistics update de data of this row
+   IF EXISTS(SELECT 1 FROM statistics WHERE date_at = v_created_at) THEN
+        UPDATE statistics
+        SET cvm_tx = v_cvm_tx, avm_tx = v_avm_tx, token_transfer = v_token_transfer, gas_used = v_gas_used, receive_count = v_receive_count,
+        send_count = v_send_count, active_accounts = v_active_accounts, gas_price = v_gas_price, blocks = v_blocks, avg_block_size = v_avg_block_size
+        WHERE date_at = v_created_at;
+    ELSE
+  -- 4.2 if not exist a previous value in the statistics table with this date insert all the data.
+       INSERT INTO statistics (date_at, cvm_tx, avm_tx, token_transfer, gas_used, receive_count, send_count,active_accounts,gas_price,blocks, avg_block_size)
+       VALUES(v_created_at, v_cvm_tx, v_avm_tx,v_token_transfer, v_gas_used, v_receive_count, v_send_count, v_active_accounts,v_gas_price, v_blocks, v_avg_block_size);
+
+    END IF;
+
+   FETCH cur1 INTO v_cvm_tx,v_created_at,v_token_transfer, v_gas_used, v_receive_count, v_send_count, v_active_accounts,v_gas_price, v_blocks, v_avm_tx, v_avg_block_size;
+  END WHILE;
+  
+  CLOSE cur1;
+END;

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -906,3 +906,90 @@ func (r *Reader) CTxDATA(ctx context.Context, p *params.TxDataParam) ([]byte, er
 func uint64Ptr(u64 uint64) *uint64 {
 	return &u64
 }
+
+func (r *Reader) UniqueAddresses(ctx context.Context, p *params.ListParams) (*models.AddressStruct, error) {
+	dbRunner, err := r.conns.DB().NewSession("unique_adresses", cfg.RequestTimeout)
+	if err != nil {
+		return &models.AddressStruct{
+			AddressInfo: []*models.UniqueAddresses{},
+		}, err
+	}
+	filterDate := utils.DateFilter(p.StartTime, p.EndTime, "created_at")
+	var UniqueAddresses []*models.UniqueAddresses
+	_, err = dbRunner.Select("COUNT(DISTINCT address) as total_addresses", filterDate+" as date_at").
+		From("magellan.address_chain").
+		Where("created_at BETWEEN ? AND ?", p.StartTime, p.EndTime).
+		GroupBy(filterDate).LoadContext(ctx, &UniqueAddresses)
+
+	if err != nil || len(UniqueAddresses) == 0 {
+		return &models.AddressStruct{
+			AddressInfo: []*models.UniqueAddresses{},
+		}, err
+	}
+	return r.DailyIncreaseInfo(UniqueAddresses), err
+}
+
+func (r *Reader) DailyIncreaseInfo(uniquea []*models.UniqueAddresses) *models.AddressStruct {
+	PreviousValue := uniquea[0].TotalAddresses
+	addressInfo := &models.AddressStruct{
+		LowestDate:  uniquea[0].DateAt,
+		HighestDate: uniquea[0].DateAt,
+	}
+	for _, address := range uniquea {
+		address.DailyIncrease = address.TotalAddresses - PreviousValue
+		PreviousValue = address.TotalAddresses
+		if address.DailyIncrease > addressInfo.HighestNumber {
+			addressInfo.HighestNumber = address.DailyIncrease
+			addressInfo.HighestDate = address.DateAt
+		}
+		if address.DailyIncrease < addressInfo.LowestNumber {
+			addressInfo.LowestNumber = address.DailyIncrease
+			addressInfo.LowestDate = address.DateAt
+		}
+	}
+	addressInfo.AddressInfo = uniquea
+	return addressInfo
+}
+
+func (r *Reader) ActiveAddresses(ctx context.Context, p *params.ListParams) (*models.AddressStruct, error) {
+	dbRunner, err := r.conns.DB().NewSession("average_block_size", cfg.RequestTimeout)
+	var addressStatistics *models.AddressStruct
+	if err != nil {
+		return &models.AddressStruct{
+			AddressInfo: []*models.UniqueAddresses{},
+		}, err
+	}
+	filterDate := utils.DateFilter(p.StartTime, p.EndTime, "created_at")
+	var ActiveAddresses []*models.ActiveAddresses
+	baseq := dbRunner.Select("COUNT(DISTINCT id_from_addr) as send_count", "COUNT(DISTINCT id_to_addr) as receive_count", filterDate+" as date_at").
+		From("cvm_transactions_txdata").
+		Where("created_at BETWEEN ? AND ?", p.StartTime, p.EndTime).
+		GroupBy(filterDate)
+
+	Active := dbRunner.Select("GREATEST(send_count, receive_count) as total", "send_count", "receive_count", "date_at").
+		From(baseq.As("bq"))
+
+	_, err = Active.LoadContext(ctx, &ActiveAddresses)
+
+	if err != nil || len(ActiveAddresses) == 0 {
+		return &models.AddressStruct{AddressInfo: []*models.ActiveAddresses{}}, err
+	}
+	_, err = dbRunner.Select("date_at as highest_date", "GREATEST(send_count, receive_count) as highest_number").
+		From(Active.As("q")).
+		OrderBy("GREATEST(send_count, receive_count)  LIMIT 1").
+		LoadContext(ctx, &addressStatistics)
+
+	if err != nil {
+		return &models.AddressStruct{AddressInfo: []*models.ActiveAddresses{}}, err
+	}
+	_, err = dbRunner.Select("date_at as lowest_date", "GREATEST(send_count, receive_count) as lowest_number").
+		From(baseq.As("q")).
+		OrderBy("GREATEST(send_count, receive_count) ASC LIMIT 1").
+		LoadContext(ctx, &addressStatistics)
+
+	if err != nil {
+		return &models.AddressStruct{AddressInfo: []*models.ActiveAddresses{}}, err
+	}
+	addressStatistics.AddressInfo = ActiveAddresses
+	return addressStatistics, err
+}

--- a/services/indexes/avax/reader_list_cblocks.go
+++ b/services/indexes/avax/reader_list_cblocks.go
@@ -166,16 +166,12 @@ func (r *Reader) AverageBlockSizeReader(ctx context.Context, p *params.ListParam
 	if err != nil {
 		return []*models.AverageBlockSize{}, err
 	}
-	filterDate := utils.DateFilter(p.StartTime, p.EndTime, "created_at")
+	filterDate := utils.DateFilter(p.StartTime, p.EndTime, "date_at")
 	var averageBlockSizeData []*models.AverageBlockSize
-	ua := dbRunner.Select("AVG(gas_used) AS AvgGasUsed", filterDate+" as date_info").
-		From("magellan.cvm_transactions_txdata").
-		Where("created_at BETWEEN ? AND ?", p.StartTime, p.EndTime).
-		GroupBy("block_idx", filterDate)
-
-	_, err = dbRunner.Select("AVG(AvgGasUsed) AS block_size", "date_info").
-		From(ua.As("q")).
-		GroupBy("date_info").LoadContext(ctx, &averageBlockSizeData)
+	_, err = dbRunner.Select("AVG(avg_block_size) AS block_size", filterDate+" as date_info").
+		From("statistics").
+		Where("date_at BETWEEN ? AND ?", p.StartTime, p.EndTime).
+		GroupBy(filterDate).LoadContext(ctx, &averageBlockSizeData)
 
 	if err != nil || len(averageBlockSizeData) == 0 {
 		return []*models.AverageBlockSize{}, err

--- a/services/indexes/avax/reader_list_cblocks.go
+++ b/services/indexes/avax/reader_list_cblocks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/chain4travel/magellan/db"
 	"github.com/chain4travel/magellan/models"
 	"github.com/chain4travel/magellan/services/indexes/params"
+	"github.com/chain4travel/magellan/utils"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -158,4 +159,27 @@ func (r *Reader) ListCBlocks(ctx context.Context, p *params.ListCBlocksParams) (
 	}
 
 	return &result, nil
+}
+
+func (r *Reader) AverageBlockSizeReader(ctx context.Context, p *params.ListParams) ([]*models.AverageBlockSize, error) {
+	dbRunner, err := r.conns.DB().NewSession("average_block_size", cfg.RequestTimeout)
+	if err != nil {
+		return []*models.AverageBlockSize{}, err
+	}
+	filterDate := utils.DateFilter(p.StartTime, p.EndTime, "created_at")
+	var averageBlockSizeData []*models.AverageBlockSize
+	ua := dbRunner.Select("AVG(gas_used) AS AvgGasUsed", filterDate+" as date_info").
+		From("magellan.cvm_transactions_txdata").
+		Where("created_at BETWEEN ? AND ?", p.StartTime, p.EndTime).
+		GroupBy("block_idx", filterDate)
+
+	_, err = dbRunner.Select("AVG(AvgGasUsed) AS block_size", "date_info").
+		From(ua.As("q")).
+		GroupBy("date_info").LoadContext(ctx, &averageBlockSizeData)
+
+	if err != nil || len(averageBlockSizeData) == 0 {
+		return []*models.AverageBlockSize{}, err
+	}
+
+	return averageBlockSizeData, err
 }

--- a/services/indexes/avax/reader_list_txs.go
+++ b/services/indexes/avax/reader_list_txs.go
@@ -22,6 +22,7 @@ import (
 	"github.com/chain4travel/magellan/db"
 	"github.com/chain4travel/magellan/models"
 	"github.com/chain4travel/magellan/services/indexes/params"
+	"github.com/chain4travel/magellan/utils"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -750,4 +751,155 @@ func selectOutputs(dbRunner dbr.SessionRunner, redeem bool) *dbr.SelectBuilder {
 		LeftJoin("avm_output_addresses", tbl+".id = avm_output_addresses.output_id").
 		LeftJoin("transactions_rewards_owners_outputs", tbl+".id = transactions_rewards_owners_outputs.id").
 		LeftJoin("addresses", "addresses.address = avm_output_addresses.address")
+}
+
+func (r *Reader) DailyTransactions(ctx context.Context, p *params.ListParams) (*models.StatisticsStruct, error) {
+	dbRunner, err := r.conns.DB().NewSession("get_transactions", cfg.RequestTimeout)
+	var transactionData []*models.TransactionsInfo
+	var statistics *models.StatisticsStruct
+	if err != nil {
+		return &models.StatisticsStruct{TxInfo: []*models.TransactionsInfo{}}, err
+	}
+
+	filterDate := utils.DateFilter(p.StartTime, p.EndTime, "created_at")
+	ua := dbRunner.Select("AVG(gas_used) AS AvgGasUsed", filterDate+" as date_at").
+		From("magellan.cvm_transactions_txdata").
+		Where("created_at BETWEEN ? AND ?", p.StartTime, p.EndTime).
+		GroupBy("block_idx", filterDate)
+
+	blockSize := dbRunner.Select("AVG(AvgGasUsed) as avg_gas", "date_at").
+		From(ua.As("q")).
+		GroupBy("date_at")
+
+	transactions := dbRunner.Select("COUNT(block) AS transactions", filterDate+" as date_at", "COUNT(DISTINCT block_idx) as blocks").
+		From("magellan.cvm_transactions_txdata").
+		GroupBy(filterDate)
+
+	baseq := dbRunner.Select("avgGas.avg_gas as avg_block_size", "txs.transactions as total_transactions", "avgGas.date_at as date", "txs.blocks AS total_block_count").
+		From(blockSize.As("avgGas")).
+		Join(transactions.As("txs"), "avgGas.date_at = txs.date_at")
+
+	_, errGas := baseq.LoadContext(ctx, &transactionData)
+
+	_, err = dbRunner.Select("date as highest_date", "CAST(avg_block_size as SIGNED) as highest_number").
+		From(baseq.As("gas")).
+		OrderBy("avg_block_size DESC LIMIT 1").
+		LoadContext(ctx, &statistics)
+
+	if err != nil {
+		return &models.StatisticsStruct{TxInfo: []*models.TransactionsInfo{}}, errGas
+	}
+	_, err = dbRunner.Select("date as lowest_date", "CAST(avg_block_size as SIGNED) as lowest_number").
+		From(baseq.As("gas")).
+		OrderBy("avg_block_size ASC LIMIT 1").
+		LoadContext(ctx, &statistics)
+
+	if err != nil || len(transactionData) == 0 {
+		return &models.StatisticsStruct{TxInfo: []*models.TransactionsInfo{}}, errGas
+	}
+	statistics.TxInfo = transactionData
+	return statistics, err
+}
+
+func (r *Reader) GasUsedPerDay(ctx context.Context, p *params.ListParams) (models.StatisticsStruct, error) {
+	dbRunner, err := r.conns.DB().NewSession("get_gas_used", cfg.RequestTimeout)
+	if err != nil {
+		return models.StatisticsStruct{TxInfo: []models.TransactionsInfo{}}, err
+	}
+	var (
+		gasUsed          []*models.GasUsedPerDate
+		statisticsStruct models.StatisticsStruct
+	)
+	filterDate := utils.DateFilter(p.StartTime, p.EndTime, "created_at")
+	sa := dbRunner.Select(filterDate+" as date", "SUM(gas_used) AS gas").
+		From("magellan.cvm_transactions_txdata").
+		Where("created_at BETWEEN ? AND ?", p.StartTime, p.EndTime).
+		GroupBy(filterDate)
+
+	_, err = sa.LoadContext(ctx, &gasUsed)
+	if err != nil {
+		return models.StatisticsStruct{TxInfo: []models.TransactionsInfo{}}, err
+	}
+	_, err = dbRunner.Select("date as highest_date", "gas as highest_number").
+		From(sa.As("gas")).
+		OrderBy("gas DESC LIMIT 1").
+		LoadContext(ctx, &statisticsStruct)
+
+	if err != nil {
+		return models.StatisticsStruct{TxInfo: []models.TransactionsInfo{}}, err
+	}
+	_, err = dbRunner.Select("date as lowest_date", "gas as lowest_number").
+		From(sa.As("gas")).
+		OrderBy("gas ASC LIMIT 1").
+		LoadContext(ctx, &statisticsStruct)
+
+	if err != nil || len(gasUsed) == 0 {
+		return models.StatisticsStruct{TxInfo: []models.TransactionsInfo{}}, err
+	}
+	statisticsStruct.TxInfo = gasUsed
+	return statisticsStruct, err
+}
+
+func (r *Reader) AvgGasPriceUsed(ctx context.Context, p *params.ListParams) (models.StatisticsStruct, error) {
+	dbRunner, err := r.conns.DB().NewSession("get_gas_used", cfg.RequestTimeout)
+	if err != nil {
+		return models.StatisticsStruct{TxInfo: []models.TransactionsInfo{}}, err
+	}
+	var gasPrice []*models.GasUsedPerDate
+	var statisticsStruct models.StatisticsStruct
+
+	filterDate := utils.DateFilter(p.StartTime, p.EndTime, "created_at")
+
+	sa := dbRunner.Select(filterDate+"AS date", "SUM(gas_price) AS gas").
+		From("magellan.cvm_transactions_txdata").
+		Where("created_at BETWEEN ? AND ?", p.StartTime, p.EndTime).
+		GroupBy(filterDate)
+
+	_, err = sa.LoadContext(ctx, &gasPrice)
+	if err != nil {
+		return models.StatisticsStruct{TxInfo: []models.TransactionsInfo{}}, err
+	}
+
+	_, err = dbRunner.Select("date as highest_date", "gas as highest_number").
+		From(sa.As("sum_gas")).
+		OrderBy("gas DESC LIMIT 1").
+		LoadContext(ctx, &statisticsStruct)
+
+	if err != nil {
+		return models.StatisticsStruct{TxInfo: []models.TransactionsInfo{}}, err
+	}
+
+	_, err = dbRunner.Select("date as lowest_date", "gas as lowest_number").
+		From(sa.As("sum_gas")).
+		OrderBy("gas ASC LIMIT 1").
+		LoadContext(ctx, &statisticsStruct)
+
+	if err != nil || len(gasPrice) == 0 {
+		return models.StatisticsStruct{TxInfo: []models.TransactionsInfo{}}, err
+	}
+
+	statisticsStruct.TxInfo = gasPrice
+	return statisticsStruct, err
+}
+
+func (r *Reader) DailyTokenTransfer(ctx context.Context, p *params.ListParams) ([]*models.TransactionsPerDate, error) {
+	dbRunner, err := r.conns.DB().NewSession("daily_token", cfg.RequestTimeout)
+	if err != nil {
+		return []*models.TransactionsPerDate{}, err
+	}
+
+	var camCount []*models.TransactionsPerDate
+
+	filterDate := utils.DateFilter(p.StartTime, p.EndTime, "created_at")
+
+	_, err = dbRunner.Select(filterDate+"AS date_at", "SUM(amount) as counter").
+		From("magellan.cvm_transactions_txdata").
+		Where("created_at BETWEEN ? AND ?", p.StartTime, p.EndTime).
+		GroupBy(filterDate).
+		LoadContext(ctx, &camCount)
+
+	if err != nil || len(camCount) == 0 {
+		return []*models.TransactionsPerDate{}, err
+	}
+	return camCount, err
 }

--- a/services/indexes/cvm/writer.go
+++ b/services/indexes/cvm/writer.go
@@ -297,7 +297,7 @@ func (w *Writer) indexBlockInternal(ctx services.ConsumerCtx, atomicTXs []*evm.T
 	if err != nil {
 		return err
 	}
-
+	size := utils.GetSizeFromStringtoFloat(block.Size().String())
 	cvmBlocks := &db.CvmBlocks{
 		Block:         block.Header().Number.String(),
 		Hash:          block.Hash().String(),
@@ -308,6 +308,7 @@ func (w *Writer) indexBlockInternal(ctx services.ConsumerCtx, atomicTXs []*evm.T
 		CreatedAt:     ctx.Time(),
 		Proposer:      proposer.Proposer,
 		ProposerTime:  proposer.TimeStamp,
+		Size:          size,
 	}
 	err = ctx.Persist().InsertCvmBlocks(ctx.Ctx(), ctx.DB(), cvmBlocks)
 

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -59,6 +59,18 @@ func (p *SearchParams) CacheKey() []string {
 	return p.ListParams.CacheKey()
 }
 
+type StatisticsParams struct {
+	ListParams ListParams
+}
+
+func (p *StatisticsParams) ForValues(v uint8, q url.Values) error {
+	return p.ListParams.ForValues(v, q)
+}
+
+func (p *StatisticsParams) CacheKey() []string {
+	return p.ListParams.CacheKey()
+}
+
 type EmissionsParams struct {
 	ListParams    ListParams
 	SubstractDays int

--- a/servicesctrl/services_control.go
+++ b/servicesctrl/services_control.go
@@ -145,6 +145,22 @@ func (s *Control) StartCacheScheduler(config *cfg.Config) error {
 	return nil
 }
 
+func (s *Control) StartStatisticsScheduler(config *cfg.Config) error {
+	// create new database connection
+	connections, err := s.DatabaseRO()
+	if err != nil {
+		return err
+	}
+	MyTimer := time.NewTimer(time.Duration(config.CacheStatisticsInterval) * time.Hour)
+
+	for range MyTimer.C {
+		MyTimer.Stop()
+		_ = s.AggregatesCache.UpdateStatisticsCache(connections)
+		MyTimer.Reset(time.Duration(config.CacheStatisticsInterval) * time.Hour)
+	}
+	return nil
+}
+
 func (s *Control) InitProduceMetrics() {
 	utils.Prometheus.CounterInit(MetricProduceProcessedCountKey, "records processed")
 	utils.Prometheus.CounterInit(MetricProduceSuccessCountKey, "records success")

--- a/utils/block.go
+++ b/utils/block.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"strconv"
+	"strings"
+)
+
+func GetSizeFromStringtoFloat(size string) float64 {
+	sizeArray := strings.Split(size, " ")
+	switch {
+	case sizeArray[1] == "TiB":
+		finalSize, _ := strconv.ParseFloat(sizeArray[0], 64)
+		return finalSize * 1099511627776
+	case sizeArray[1] == "GiB":
+		finalSize, _ := strconv.ParseFloat(sizeArray[0], 64)
+		return finalSize * 1073741824
+	case sizeArray[1] == "MiB":
+		finalSize, _ := strconv.ParseFloat(sizeArray[0], 64)
+		return finalSize * 1048576
+	case sizeArray[1] == "KiB":
+		finalSize, _ := strconv.ParseFloat(sizeArray[0], 64)
+		return finalSize * 1024
+	default:
+		finalSize, _ := strconv.ParseFloat(sizeArray[0], 64)
+		return finalSize
+	}
+}

--- a/utils/dbutils.go
+++ b/utils/dbutils.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"strings"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 )
@@ -37,4 +38,21 @@ func ForceParseTimeParam(dsn string) (string, error) {
 
 	// Re-encode as a string
 	return u.FormatDSN(), nil
+}
+
+func DateFilter(startTime time.Time, endTime time.Time, columnName string) string {
+	monthsBetween := int(endTime.Month() - startTime.Month())
+	yearsBetween := endTime.Year() - startTime.Year()
+	var filterDate string
+	switch {
+	// if the date range is greater than or equal to one month the values are averaged per month
+	case (monthsBetween >= 1 || monthsBetween < 0 || startTime.Year() == 1) && yearsBetween == 0:
+		filterDate = "DATE_FORMAT(created_at,'%Y-%m-01')"
+	// if the date range is greater than or equal to one year the values are averaged per year
+	case yearsBetween > 0:
+		filterDate = "DATE_FORMAT(created_at,'%Y-01-01')"
+	default:
+		filterDate = "DATE_FORMAT(created_at,'%Y-%m-%d')"
+	}
+	return filterDate
 }

--- a/utils/dbutils.go
+++ b/utils/dbutils.go
@@ -47,12 +47,12 @@ func DateFilter(startTime time.Time, endTime time.Time, columnName string) strin
 	switch {
 	// if the date range is greater than or equal to one month the values are averaged per month
 	case (monthsBetween >= 1 || monthsBetween < 0 || startTime.Year() == 1) && yearsBetween == 0:
-		filterDate = "DATE_FORMAT(created_at,'%Y-%m-01')"
+		filterDate = "DATE_FORMAT(" + columnName + ",'%Y-%m-01')"
 	// if the date range is greater than or equal to one year the values are averaged per year
 	case yearsBetween > 0:
-		filterDate = "DATE_FORMAT(created_at,'%Y-01-01')"
+		filterDate = "DATE_FORMAT(" + columnName + ",'%Y-01-01')"
 	default:
-		filterDate = "DATE_FORMAT(created_at,'%Y-%m-%d')"
+		filterDate = "DATE_FORMAT(" + columnName + ",'%Y-%m-%d')"
 	}
 	return filterDate
 }


### PR DESCRIPTION
Description:
1. Seven new endpoints were added to get the information about blockchain statistics from database:

**Active addresses:** The Active Addresses endpoint ets the information of the daily number of unique addresses that were active on the network as a sender or receiver.

**Unique adresses:** The Unique Addresses endpoint ets the information of the total distinct numbers of address on the Camino blockchain and the increase in the number of address daily.

**Average blocksize:**  The Average Block Size endpoint indicates the historical average block size in bytes of the Camino blockchain.

**Daily Transactions:**  The Daily Transations endpoint ets the information of the total number of transactions on the Camino blockchain with daily average difficulty, average block size and total block.

**Daily token transfer:** The daily token transfer endpoint gets the information of the number of Camino tokens transferred daily.

**Daily Gas Used:** The Daily Gas Used endpoint gets the information of the historical total daily gas used of the Camino network

**Avg Gas Price Used:** The Avg Gas Price Used endpoint gets the information of the daily average gas price used of the Camino network.
     
All these endpoints have a filter to limit the results by day, month, or year depending on the range of dates in the startTime and 
endTime in request parameter:
  
3. A new table was created to store information about the historical network statistics.
4. Added a stored procedure that retrieves the information by last day and update the statistics cache table.
5. A scheduler was created that executes the above stored procedure every hour to update the accumulated information of the day.

