### PR TITLE
Blockchain Statistics Alternative Solution

### DIFF
--- a/api/v2.go
+++ b/api/v2.go
@@ -120,6 +120,13 @@ func AddV2Routes(ctx *Context, router *web.Router, path string, indexBytes []byt
 		Get("/addressChains", (*V2Context).AddressChains).
 		Post("/addressChains", (*V2Context).AddressChainsPost).
 		Post("/validatorsInfo", (*V2Context).ValidatorsInfo).
+		Get("/activeAddresses", (*V2Context).ActiveAddresses).
+		Get("/uniqueAddresses", (*V2Context).UniqueAddresses).
+		Get("/averageBlockSize", (*V2Context).AverageBlockSize).
+		Get("/dailyTransactions", (*V2Context).DailyTransactions).
+		Get("/dailyGasUsed", (*V2Context).DailyGasUsed).
+		Get("/avgGasPriceUsed", (*V2Context).AvgGasPriceUsed).
+		Get("/dailyTokenTransfer", (*V2Context).DailyTokenTransfer).
 		Get("/dailyEmissions", (*V2Context).DailyEmissions).
 		Get("/networkEmissions", (*V2Context).NetworkEmissions).
 		Get("/transactionEmissions", (*V2Context).TransactionEmissions).
@@ -170,6 +177,188 @@ func (c *V2Context) ValidatorsInfo(w web.ResponseWriter, r *web.Request) {
 		Key: c.cacheKeyForParams("geoIPValidatorsInfo", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return utils.GetValidatorsGeoIPInfo(p.RPC, &c.sc.Services.GeoIP, c.sc.Logger())
+		},
+	})
+}
+
+func (c *V2Context) ActiveAddresses(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams("activeAddresses", p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.ActiveAddresses(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) UniqueAddresses(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams("uniqueAddresses", p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.UniqueAddresses(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) AverageBlockSize(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams("AverageBlockSize", p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.AverageBlockSizeReader(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) DailyTransactions(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("dailyTransactionsChart %s", p.ListParams.ID)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.DailyTransactions(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) DailyGasUsed(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("DailyGasUsed %s", p.ListParams.ID)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.GasUsedPerDay(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) AvgGasPriceUsed(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("AvgGasPriceUsed %s", p.ListParams.ID)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.AvgGasPriceUsed(ctx, &p.ListParams)
+		},
+	})
+}
+
+func (c *V2Context) DailyTokenTransfer(w web.ResponseWriter, r *web.Request) {
+	collectors := utils.NewCollectors(
+		utils.NewCounterObserveMillisCollect(MetricMillis),
+		utils.NewCounterIncCollect(MetricCount),
+		utils.NewCounterObserveMillisCollect(MetricAggregateMillis),
+		utils.NewCounterIncCollect(MetricAggregateCount),
+	)
+	defer func() {
+		_ = collectors.Collect()
+	}()
+
+	p := &params.StatisticsParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+	key := fmt.Sprintf("DailyTokenTransfer %s", p.ListParams.ID)
+	c.WriteCacheable(w, caching.Cacheable{
+		TTL: 1 * time.Hour,
+		Key: c.cacheKeyForParams(key, p),
+		CacheableFn: func(ctx context.Context) (interface{}, error) {
+			return c.avaxReader.DailyTokenTransfer(ctx, &p.ListParams)
 		},
 	})
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -65,18 +65,19 @@ type AggregatesFeesMain struct {
 }
 
 type Config struct {
-	NetworkID           uint32 `json:"networkID"`
-	Chains              `json:"chains"`
-	Services            `json:"services"`
-	MetricsListenAddr   string `json:"metricsListenAddr"`
-	AdminListenAddr     string `json:"adminListenAddr"`
-	Features            map[string]struct{}
-	CchainID            string `json:"cchainId"`
-	CaminoNode          string `json:"caminoNode"`
-	NodeInstance        string `json:"nodeInstance"`
-	CacheUpdateInterval uint64 `json:"cacheUpdateInterval"`
-	AP5Activation       uint64 `json:"ap5Activation"`
-	BanffActivation     uint64 `json:"banffActivation"`
+	NetworkID               uint32 `json:"networkID"`
+	Chains                  `json:"chains"`
+	Services                `json:"services"`
+	MetricsListenAddr       string `json:"metricsListenAddr"`
+	AdminListenAddr         string `json:"adminListenAddr"`
+	Features                map[string]struct{}
+	CchainID                string `json:"cchainId"`
+	CaminoNode              string `json:"caminoNode"`
+	NodeInstance            string `json:"nodeInstance"`
+	CacheUpdateInterval     uint64 `json:"cacheUpdateInterval"`
+	CacheStatisticsInterval uint64 `json:"cacheStatisticsInterval"`
+	AP5Activation           uint64 `json:"ap5Activation"`
+	BanffActivation         uint64 `json:"banffActivation"`
 }
 
 type Chain struct {
@@ -192,11 +193,12 @@ func NewFromFile(filePath string) (*Config, error) {
 				AuthorizationToken: tokenInmutable,
 			},
 		},
-		CchainID:            v.GetString(keysStreamProducerCchainID),
-		CaminoNode:          v.GetString(keysStreamProducerCaminoNode),
-		NodeInstance:        v.GetString(keysStreamProducerNodeInstance),
-		CacheUpdateInterval: uint64(v.GetInt(keysCacheUpdateInterval)),
-		AP5Activation:       uint64(ap5Activation),
-		BanffActivation:     uint64(banffActivation),
+		CchainID:                v.GetString(keysStreamProducerCchainID),
+		CaminoNode:              v.GetString(keysStreamProducerCaminoNode),
+		NodeInstance:            v.GetString(keysStreamProducerNodeInstance),
+		CacheUpdateInterval:     uint64(v.GetInt(keysCacheUpdateInterval)),
+		CacheStatisticsInterval: uint64(v.GetInt(keysCacheStatisticsInterval)),
+		AP5Activation:           uint64(ap5Activation),
+		BanffActivation:         uint64(banffActivation),
 	}, nil
 }

--- a/cfg/defaults.go
+++ b/cfg/defaults.go
@@ -16,6 +16,7 @@ package cfg
 const defaultJSON = `{
   "networkID": 1001,
   "cacheUpdateInterval": "5",
+  "cacheStatisticsInterval": "1",
   "logDirectory": "/tmp/magellan/logs",
   "listenAddr": ":8080",
   "chains": {},

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -43,5 +43,6 @@ const (
 
 	keysStreamProducerCchainID = "cchainID"
 
-	keysCacheUpdateInterval = "cacheUpdateInterval"
+	keysCacheUpdateInterval     = "cacheUpdateInterval"
+	keysCacheStatisticsInterval = "cacheStatisticsInterval"
 )

--- a/cmds/magelland/magelland.go
+++ b/cmds/magelland/magelland.go
@@ -212,6 +212,12 @@ func createAPICmds(sc *servicesctrl.Control, config *cfg.Config, runErr *error) 
 					return
 				}
 			}()
+			go func() {
+				err := sc.StartStatisticsScheduler(config)
+				if err != nil {
+					return
+				}
+			}()
 			lc, err := api.NewServer(sc, *config)
 			if err != nil {
 				*runErr = err

--- a/db/dbmodel.go
+++ b/db/dbmodel.go
@@ -1097,6 +1097,7 @@ type CvmBlocks struct {
 	CreatedAt     time.Time
 	Proposer      string
 	ProposerTime  *time.Time
+	Size          float64
 }
 
 func (p *persist) QueryCvmBlock(
@@ -1128,8 +1129,8 @@ func (p *persist) InsertCvmBlocks(
 ) error {
 	var err error
 	_, err = sess.
-		InsertBySql("insert into "+TableCvmBlocks+" (block,hash,chain_id,evm_tx,atomic_tx,serialization,created_at, proposer,proposer_time) values("+v.Block+",?,?,?,?,?,?,?,?)",
-			v.Hash, v.ChainID, v.EvmTx, v.AtomicTx, v.Serialization, v.CreatedAt, v.Proposer, v.ProposerTime).
+		InsertBySql("insert into "+TableCvmBlocks+" (block,hash,chain_id,evm_tx,atomic_tx,serialization,created_at, proposer,proposer_time,size) values("+v.Block+",?,?,?,?,?,?,?,?,?)",
+			v.Hash, v.ChainID, v.EvmTx, v.AtomicTx, v.Serialization, v.CreatedAt, v.Proposer, v.ProposerTime, v.Size).
 		ExecContext(ctx)
 	if err != nil && !utils.ErrIsDuplicateEntryError(err) {
 		return EventErr(TableCvmBlocks, false, err)

--- a/models/collections.go
+++ b/models/collections.go
@@ -153,6 +153,59 @@ type CResult struct {
 	Hash   string `json:"hash"`
 }
 
+type StatisticsStruct struct {
+	HighestNumber float64     `json:"highestValue"`
+	HighestDate   string      `json:"highestDate"`
+	LowestNumber  float64     `json:"lowerValue"`
+	LowestDate    string      `json:"lowerDate"`
+	TxInfo        interface{} `json:"txInfo"`
+}
+
+type TransactionsInfo struct {
+	Date              string  `json:"date"`
+	TotalTransactions int     `json:"totalTransactions"`
+	AvgBlockTime      float32 `json:"avgBlockTime"`
+	AvgBlockSize      float32 `json:"avgBlockSize"`
+	TotalBlockCount   int     `json:"totalBlockCount"`
+	TotalUnclesCount  int     `json:"totalUnclesCount"`
+	NewAddressSeen    string  `json:"newAddressSeen"`
+}
+
+type TransactionsPerDate struct {
+	Counter float64 `json:"counter"`
+	DateAt  string  `json:"dateAt"`
+}
+
+type GasUsedPerDate struct {
+	Gas  float32 `json:"avgGas"`
+	Date string  `json:"date"`
+}
+
+type AverageBlockSize struct {
+	BlockSize float64 `json:"blockSize"`
+	DateInfo  string  `json:"dateInfo"`
+}
+
+type AddressStruct struct {
+	HighestNumber int         `json:"highestValue"`
+	HighestDate   string      `json:"highestDate"`
+	LowestNumber  int         `json:"lowestValue"`
+	LowestDate    string      `json:"lowestDate"`
+	AddressInfo   interface{} `json:"addressInfo"`
+}
+type UniqueAddresses struct {
+	TotalAddresses int    `json:"totalAddresses"`
+	DateAt         string `json:"dateAt"`
+	DailyIncrease  int    `json:"dailyIncrease"`
+}
+
+type ActiveAddresses struct {
+	Total        int    `json:"total"`
+	ReceiveCount int    `json:"receiveCount"`
+	SendCount    int    `json:"sendCount"`
+	DateAt       string `json:"dateAt"`
+}
+
 // SearchResults represents a set of items returned for a search query.
 type SearchResults struct {
 	// Count is the total number of matching results
@@ -297,6 +350,42 @@ type Validator struct {
 	Country    string     `json:"country"`
 	CountryISO string     `json:"countryISO"`
 	City       string     `json:"city"`
+}
+
+type StatisticsCache struct {
+	DateAt         string  `json:"dateAt"`
+	CvmTx          int     `json:"cvmTx"`
+	AvmTx          int     `json:"avmTx"`
+	ReceiveCount   int     `json:"receiveCount"`
+	SendCount      int     `json:"sendCount"`
+	ActiveAccounts int     `json:"activeAccounts"`
+	Blocks         int     `json:"blocks"`
+	GasPrice       float32 `json:"gasPrice"`
+	TokenTransfer  float32 `json:"tokenTransfer"`
+	GasUsed        float32 `json:"gasUsed"`
+	AvgBlockSize   float32 `json:"avgBlockSize"`
+}
+
+type CvmStatisticsCache struct {
+	DateAt         string  `json:"dateAt"`
+	CvmTx          int     `json:"cvmTx"`
+	ReceiveCount   int     `json:"receiveCount"`
+	SendCount      int     `json:"sendCount"`
+	ActiveAccounts int     `json:"activeAccounts"`
+	Blocks         int     `json:"blocks"`
+	GasPrice       float32 `json:"gasPrice"`
+	GasUsed        float32 `json:"gasUsed"`
+	TokenTransfer  float32 `json:"tokenTransfer"`
+}
+
+type AvmStatisticsCache struct {
+	DateAt string `json:"dateAt"`
+	AvmTx  int    `json:"avmTx"`
+}
+
+type CvmBlocksStatisticsCache struct {
+	DateAt       string  `json:"dateAt"`
+	AvgBlockSize float32 `json:"avgBlockSize"`
 }
 
 /*******************  Merging  ***********************/

--- a/services/db/migrations/051_add_block_size.down.sql
+++ b/services/db/migrations/051_add_block_size.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cmv_blocks DROP COLUMN size;

--- a/services/db/migrations/051_add_block_size.up.sql
+++ b/services/db/migrations/051_add_block_size.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cvm_blocks ADD COLUMN `size` FLOAT default 0 AFTER `proposer_time`;

--- a/services/db/migrations/052_create_info_schema.down.sql
+++ b/services/db/migrations/052_create_info_schema.down.sql
@@ -1,0 +1,1 @@
+drop table statistics;

--- a/services/db/migrations/052_create_info_schema.up.sql
+++ b/services/db/migrations/052_create_info_schema.up.sql
@@ -1,0 +1,16 @@
+-- magellan.Test definition
+
+CREATE TABLE `statistics` (
+  `date_at` date NOT NULL,
+  `cvm_tx` int DEFAULT NULL,
+  `avm_tx` int DEFAULT NULL,
+  `token_transfer` float DEFAULT NULL,
+  `gas_used` float DEFAULT NULL,
+  `receive_count` int DEFAULT NULL,
+  `send_count` int DEFAULT NULL,
+  `active_accounts` int DEFAULT NULL,
+  `gas_price` float DEFAULT NULL,
+  `blocks` int DEFAULT NULL,
+  `avg_block_size`float DEFAULT NULL,
+  PRIMARY KEY (`date_at`)
+);

--- a/services/indexes/cvm/writer.go
+++ b/services/indexes/cvm/writer.go
@@ -297,7 +297,7 @@ func (w *Writer) indexBlockInternal(ctx services.ConsumerCtx, atomicTXs []*evm.T
 	if err != nil {
 		return err
 	}
-
+	size := utils.GetSizeFromStringtoFloat(block.Size().String())
 	cvmBlocks := &db.CvmBlocks{
 		Block:         block.Header().Number.String(),
 		Hash:          block.Hash().String(),
@@ -308,6 +308,7 @@ func (w *Writer) indexBlockInternal(ctx services.ConsumerCtx, atomicTXs []*evm.T
 		CreatedAt:     ctx.Time(),
 		Proposer:      proposer.Proposer,
 		ProposerTime:  proposer.TimeStamp,
+		Size:          size,
 	}
 	err = ctx.Persist().InsertCvmBlocks(ctx.Ctx(), ctx.DB(), cvmBlocks)
 

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -59,6 +59,18 @@ func (p *SearchParams) CacheKey() []string {
 	return p.ListParams.CacheKey()
 }
 
+type StatisticsParams struct {
+	ListParams ListParams
+}
+
+func (p *StatisticsParams) ForValues(v uint8, q url.Values) error {
+	return p.ListParams.ForValues(v, q)
+}
+
+func (p *StatisticsParams) CacheKey() []string {
+	return p.ListParams.CacheKey()
+}
+
 type EmissionsParams struct {
 	ListParams    ListParams
 	SubstractDays int

--- a/servicesctrl/services_control.go
+++ b/servicesctrl/services_control.go
@@ -145,6 +145,25 @@ func (s *Control) StartCacheScheduler(config *cfg.Config) error {
 	return nil
 }
 
+func (s *Control) StartStatisticsScheduler(config *cfg.Config) error {
+	// create new database connection
+	connections, err := s.DatabaseRO()
+	if err != nil {
+		return err
+	}
+	if err != nil {
+		s.Logger().Info(err.Error())
+	}
+	MyTimer := time.NewTimer(time.Duration(config.CacheStatisticsInterval) * time.Hour)
+
+	for range MyTimer.C {
+		MyTimer.Stop()
+		_ = s.AggregatesCache.UpdateStatistics(connections)
+		MyTimer.Reset(time.Duration(config.CacheStatisticsInterval) * time.Hour)
+	}
+	return nil
+}
+
 func (s *Control) InitProduceMetrics() {
 	utils.Prometheus.CounterInit(MetricProduceProcessedCountKey, "records processed")
 	utils.Prometheus.CounterInit(MetricProduceSuccessCountKey, "records success")

--- a/utils/block.go
+++ b/utils/block.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"strconv"
+	"strings"
+)
+
+func GetSizeFromStringtoFloat(size string) float64 {
+	sizeArray := strings.Split(size, " ")
+	switch {
+	case sizeArray[1] == "TiB":
+		finalSize, _ := strconv.ParseFloat(sizeArray[0], 64)
+		return finalSize * 1099511627776
+	case sizeArray[1] == "GiB":
+		finalSize, _ := strconv.ParseFloat(sizeArray[0], 64)
+		return finalSize * 1073741824
+	case sizeArray[1] == "MiB":
+		finalSize, _ := strconv.ParseFloat(sizeArray[0], 64)
+		return finalSize * 1048576
+	case sizeArray[1] == "KiB":
+		finalSize, _ := strconv.ParseFloat(sizeArray[0], 64)
+		return finalSize * 1024
+	default:
+		finalSize, _ := strconv.ParseFloat(sizeArray[0], 64)
+		return finalSize
+	}
+}

--- a/utils/blockchain_statistics.go
+++ b/utils/blockchain_statistics.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"strings"
+
+	"github.com/chain4travel/magellan/models"
+)
+
+func UnionStatistics(
+	cvmLatestTx []*models.CvmStatisticsCache,
+	cvmLatestBlocks []*models.CvmBlocksStatisticsCache,
+	avmLatestTx []*models.AvmStatisticsCache) []models.StatisticsCache {
+	statisticsCache := []models.StatisticsCache{}
+	// set all the information from cvmTx in statisticsCache variable
+	setCvmTxStatistics(&statisticsCache, cvmLatestTx)
+	setCvmBlockStatistics(&statisticsCache, cvmLatestBlocks)
+	setAvmTxStatistics(&statisticsCache, avmLatestTx)
+	return statisticsCache
+}
+
+func setCvmTxStatistics(statistics *[]models.StatisticsCache, cvmLatestTx []*models.CvmStatisticsCache) {
+	for _, cvmTx := range cvmLatestTx {
+		dateAt := strings.Split(cvmTx.DateAt, "T")[0]
+		*statistics = append(*statistics,
+			models.StatisticsCache{
+				DateAt:         dateAt,
+				CvmTx:          cvmTx.CvmTx,
+				ReceiveCount:   cvmTx.ReceiveCount,
+				SendCount:      cvmTx.SendCount,
+				ActiveAccounts: cvmTx.ActiveAccounts,
+				Blocks:         cvmTx.Blocks,
+				GasPrice:       cvmTx.GasPrice,
+				GasUsed:        cvmTx.GasUsed,
+				TokenTransfer:  cvmTx.TokenTransfer,
+			})
+	}
+}
+
+func setCvmBlockStatistics(statistics *[]models.StatisticsCache, cvmBlocks []*models.CvmBlocksStatisticsCache) {
+	for _, cvmBlock := range cvmBlocks {
+		dateAt := strings.Split(cvmBlock.DateAt, "T")[0]
+		statisticIndex := getLatestTxIndex(statistics, dateAt)
+		if statisticIndex < 0 {
+			*statistics = append(*statistics,
+				models.StatisticsCache{
+					DateAt:       dateAt,
+					AvgBlockSize: cvmBlock.AvgBlockSize,
+				})
+		} else {
+			(*statistics)[statisticIndex].AvgBlockSize = cvmBlock.AvgBlockSize
+		}
+	}
+}
+
+func setAvmTxStatistics(statistics *[]models.StatisticsCache, avmLatestTx []*models.AvmStatisticsCache) {
+	for _, avmTx := range avmLatestTx {
+		dateAt := strings.Split(avmTx.DateAt, "T")[0]
+		statisticIndex := getLatestTxIndex(statistics, dateAt)
+		if statisticIndex < 0 {
+			*statistics = append(*statistics,
+				models.StatisticsCache{
+					DateAt: dateAt,
+					AvmTx:  avmTx.AvmTx,
+				})
+		} else {
+			(*statistics)[statisticIndex].AvmTx = avmTx.AvmTx
+		}
+	}
+}
+
+func getLatestTxIndex(statistics *[]models.StatisticsCache, date string) int {
+	for idx, statistic := range *statistics {
+		if statistic.DateAt == date {
+			return idx
+		}
+	}
+	return -1
+}

--- a/utils/dbutils.go
+++ b/utils/dbutils.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"strings"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 )
@@ -37,4 +38,21 @@ func ForceParseTimeParam(dsn string) (string, error) {
 
 	// Re-encode as a string
 	return u.FormatDSN(), nil
+}
+
+func DateFilter(startTime time.Time, endTime time.Time, columnName string) string {
+	monthsBetween := int(endTime.Month() - startTime.Month())
+	yearsBetween := endTime.Year() - startTime.Year()
+	var filterDate string
+	switch {
+	// if the date range is greater than or equal to one month the values are averaged per month
+	case (monthsBetween >= 1 || monthsBetween < 0 || startTime.Year() == 1) && yearsBetween == 0:
+		filterDate = "DATE_FORMAT(" + columnName + ",'%Y-%m-01')"
+	// if the date range is greater than or equal to one year the values are averaged per year
+	case yearsBetween > 0:
+		filterDate = "DATE_FORMAT(" + columnName + ",'%Y-01-01')"
+	default:
+		filterDate = "DATE_FORMAT(" + columnName + ",'%Y-%m-%d')"
+	}
+	return filterDate
 }


### PR DESCRIPTION
## Description:

1. Seven new endpoints were added to get the information about blockchain statistics from database:

   - **Active addresse**: The Active Addresses endpoint gets the information of the daily number of unique addresses that were active on the network as a sender or receiver.
    
   - **Unique adresses**: The Unique Addresses endpoint gets the information of the total distinct numbers of address on the Camino blockchain and the increase in the number of address daily.
    
   - **Average blocksize**: The Average Block Size endpoint indicates the historical average block size in bytes of the Camino blockchain.
    
   - **Daily Transactions**: The Daily Transations endpoint gets the information of the total number of transactions on the Camino blockchain with daily average difficulty, average block size and total block.
    
   - **Daily token transfer**: The daily token transfer endpoint gets the information of the number of Camino tokens transferred daily.
    
   - **Daily Gas Used**: The Daily Gas Used endpoint gets the information of the historical total daily gas used of the Camino network
    
   - **Avg Gas Price Used**: The Avg Gas Price Used endpoint gets the information of the daily average gas price used of the Camino network.

    ***All these endpoints have a filter to limit the results by day, month, or year depending on the range of dates in the startTime and endTime in request parameter***

2. A new table was created to store information about the historical network statistics.
3. Changed the stored procedure solution (#46 ) to a Go function to make it more readable and easy to test.
  - This function retrieves the information by last transactions date, based on the last date in statistics table, and updates the statistics table information.
4. A scheduler was created that executes the above  go function every hour to update the accumulated information of the lastest day in transactions cache.


## How this was tested: 

A script was used to send payload to the blockchain for 6 hours, evaluating the time difference between the stored procedure and the go function.

Both functionalities were tested under the same conditions:
||First Execution||Second Execution||
|--|--|--|--|--|
||stored procedure|go function|stored procedure|go function|
|--|--|--|--|--|
|17222 tx  | 198.8577 ms | 549.3676 ms| 179.9241 ms | 388.1340 ms|
|35217 tx  | 286.4985 ms | 132.5670 ms| 263.1577 ms | 463.9584 ms| 
|53196 tx  | 251.0390 ms | 478.2261 ms| 284.4418 ms | 482.3894 ms|
|71211 tx  | 268.0907 ms | 274.0069 ms|263.7029 ms | 274.4881 ms|
|89201 tx  | - ms | - ms| - ms | 550.1774 ms|