### PR TITLE
Daily Transactions Without Cross Chain Tx and Fix in active addresses

### DIFF
--- a/models/collections.go
+++ b/models/collections.go
@@ -388,6 +388,11 @@ type CvmBlocksStatisticsCache struct {
 	AvgBlockSize float32 `json:"avgBlockSize"`
 }
 
+type AddressesCache struct {
+	Address string `json:"address"`
+	DateAt  string `json:"dateAt"`
+}
+
 /*******************  Merging  ***********************/
 
 type AggregateMerge interface {

--- a/servicesctrl/services_control.go
+++ b/servicesctrl/services_control.go
@@ -158,7 +158,7 @@ func (s *Control) StartStatisticsScheduler(config *cfg.Config) error {
 
 	for range MyTimer.C {
 		MyTimer.Stop()
-		_ = s.AggregatesCache.UpdateStatistics(connections)
+		_ = s.AggregatesCache.UpdateStatistics(connections, config.Chains)
 		MyTimer.Reset(time.Duration(config.CacheStatisticsInterval) * time.Hour)
 	}
 	return nil


### PR DESCRIPTION
## Why this should be merged?

- Fixed the total number of transactions count on the Daily Transactions endpoint in blockchain statistics so that cross chain transactions are excluded.
- The active addresses function was fixed to count propertly the total number of active addresses