### PR TITLE
Add error response on aggregates when chainID param is missing

### DIFF
--- a/api/v2.go
+++ b/api/v2.go
@@ -469,6 +469,10 @@ func (c *V2Context) TxfeeAggregate(w web.ResponseWriter, r *web.Request) {
 	}
 
 	p.ChainIDs = params.ForValueChainID(c.chainID, p.ChainIDs)
+	if len(p.ChainIDs) == 0 {
+		c.WriteErr(w, 400, fmt.Errorf("chainID is required"))
+		return
+	}
 
 	c.WriteCacheable(w, caching.Cacheable{
 		Key: c.cacheKeyForParams("aggregate_txfee", p),
@@ -496,6 +500,10 @@ func (c *V2Context) Aggregate(w web.ResponseWriter, r *web.Request) {
 	}
 
 	p.ChainIDs = params.ForValueChainID(c.chainID, p.ChainIDs)
+	if len(p.ChainIDs) == 0 {
+		c.WriteErr(w, 400, fmt.Errorf("chainID is required"))
+		return
+	}
 
 	c.WriteCacheable(w, caching.Cacheable{
 		Key: c.cacheKeyForParams("aggregate", p),


### PR DESCRIPTION
## Description ##
This PR adds an error 400 response on magellan api aggregates endpoints (`/aggregates` and `/txfeeAggregates`) instead of panicking.  