### PR TITLE
Control Update Statistics Warning

### DIFF
--- a/caching/aggregates_cache.go
+++ b/caching/aggregates_cache.go
@@ -537,7 +537,7 @@ func getMaxCacheDate(dbRunner *dbr.Session) time.Time {
 		MaxDate time.Time `json:"maxDate"`
 	}
 	_, err := dbRunner.
-		Select("MAX(date_at) as max_date").
+		Select("COALESCE(MAX(date_at), DATE('0001-01-01')) as max_date").
 		From("statistics").
 		Load(&cacheDate)
 


### PR DESCRIPTION
## Why this should be merged
- Added handling of the warning that occurs when the statistics table was going to be updated for the first time

Warning: 
`WARN utils/eventrcvr.go:61 event error {"name": "update_statistics", "eventName": "dbr.select.load.scan", "error": "sql: Scan error on column index 0, name "max_date": unsupported Scan, storing driver.Value type <nil> into type *time.Time"}`

## How this works:
the sql function "Coalesce" prevents the query from returning a null and instead sends the zero date

## How this was tested:
several requests were made to the database and the cache service was executed to verify that the query was successful.
In addition to this, the unit and integration tests were executed to verify that the change had not affected the cache