### PR TITLE
Update Blockchain Statistics Filter To Add Limit of Days

### DIFF
--- a/services/indexes/avax/reader_test.go
+++ b/services/indexes/avax/reader_test.go
@@ -969,7 +969,7 @@ func initDataTest(t *testing.T) error {
 }
 
 func getWantedDate(startTime time.Time, endTime time.Time, timeNow time.Time) string {
-	dateFilter := utils.DateFilter(startTime, endTime, "")
+	dateFilter := utils.DateFormat(startTime, endTime, "")
 	var date string
 
 	switch {

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -64,7 +64,18 @@ type StatisticsParams struct {
 }
 
 func (p *StatisticsParams) ForValues(v uint8, q url.Values) error {
-	return p.ListParams.ForValues(v, q)
+	err := p.ListParams.ForValues(v, q)
+	/*
+		by default the magellan has the default value established, in case the value is not sent in the
+		request, is 5000.
+		To control the number of results requested from the database, there is a default filter that groups
+		the results by day, month or year, therefore the limit must be eliminated so that it is not
+		applied to the query, this is why that the value is set to zero
+	*/
+	if p.ListParams.Limit == 5000 {
+		p.ListParams.Limit = 0
+	}
+	return err
 }
 
 func (p *StatisticsParams) CacheKey() []string {

--- a/utils/dbutils.go
+++ b/utils/dbutils.go
@@ -40,19 +40,19 @@ func ForceParseTimeParam(dsn string) (string, error) {
 	return u.FormatDSN(), nil
 }
 
-func DateFilter(startTime time.Time, endTime time.Time, columnName string) string {
+func DateFormat(startTime time.Time, endTime time.Time, columnName string) string {
 	monthsBetween := int(endTime.Month() - startTime.Month())
 	yearsBetween := endTime.Year() - startTime.Year()
-	var filterDate string
+	var dateFormat string
 	switch {
 	// if the date range is greater than or equal to one month the values are averaged per month
 	case (monthsBetween >= 1 || monthsBetween < 0 || startTime.Year() == 1) && yearsBetween == 0:
-		filterDate = "DATE_FORMAT(" + columnName + ",'%Y-%m-01')"
+		dateFormat = "DATE_FORMAT(" + columnName + ",'%Y-%m-01')"
 	// if the date range is greater than or equal to one year the values are averaged per year
 	case yearsBetween > 0:
-		filterDate = "DATE_FORMAT(" + columnName + ",'%Y-01-01')"
+		dateFormat = "DATE_FORMAT(" + columnName + ",'%Y-01-01')"
 	default:
-		filterDate = "DATE_FORMAT(" + columnName + ",'%Y-%m-%d')"
+		dateFormat = "DATE_FORMAT(" + columnName + ",'%Y-%m-%d')"
 	}
-	return filterDate
+	return dateFormat
 }


### PR DESCRIPTION
## Why this should be merged

- Add a limit in Blockchain Statistics endpoints to get an specific number of days in the response.
 In case the param has not been configured, the results will continue to be obtained with the previous filter configuration

(If the results are obtained with the previous filter, they will be averaged depending on the number of days sent in the request. If the request is made with days within the same month, it will obtain daily results. If it is done between different months, the average of the results of each month, and if it is done between different years, the average of the annual results will be obtained.

It is important to note that the results will be obtained in the format "YYYY-MM-01" if the query is monthly and "YYYY-01-01" if the query is annual.)

 ## How this was tested:
several requests were made to the database and the cache service was executed to verify that the query was successful.
In addition to this, the unit and integration tests were executed to verify that the change had not affected the expected results.