### PR TITLE
Get monthly average results in statistics filter if the query is less than two years

### DIFF
--- a/utils/dbutils.go
+++ b/utils/dbutils.go
@@ -45,14 +45,15 @@ func DateFormat(startTime time.Time, endTime time.Time, columnName string) strin
 	yearsBetween := endTime.Year() - startTime.Year()
 	var dateFormat string
 	switch {
-	// if the date range is greater than or equal to one month the values are averaged per month
-	case (monthsBetween >= 1 || monthsBetween < 0 || startTime.Year() == 1) && yearsBetween == 0:
-		dateFormat = "DATE_FORMAT(" + columnName + ",'%Y-%m-01')"
-	// if the date range is greater than or equal to one year the values are averaged per year
-	case yearsBetween > 0:
-		dateFormat = "DATE_FORMAT(" + columnName + ",'%Y-01-01')"
-	default:
+	case monthsBetween == 0 && yearsBetween == 0:
 		dateFormat = "DATE_FORMAT(" + columnName + ",'%Y-%m-%d')"
+	// if the date range is greater to 2 year the values are averaged per year
+	case yearsBetween > 2:
+		dateFormat = "DATE_FORMAT(" + columnName + ",'%Y-01-01')"
+	// if the date range is less or equal to 2 years and months between are more than one the values are
+	// averaged per month
+	default:
+		dateFormat = "DATE_FORMAT(" + columnName + ",'%Y-%m-01')"
 	}
 	return dateFormat
 }


### PR DESCRIPTION
## Why this should be merged?

- The blockchain statistics filter was changed to average the results per month if the query dates are less or equal than two years. 

This change was made to limit the number of responses to get a maximum of 30 results by averaging the information within the determined date range per month

## How this was tested:

several requests were made to the database and the cache service was executed to verify that the query was successful.
In addition to this, the unit and integration tests were executed to verify that the change had not affected the expected results.