### PR TITLE
[PVM, DAC] Txs and proposals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.3 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
+	github.com/cespare/cp v1.0.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 // indirect
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,7 @@ github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
+github.com/btcsuite/btcd v0.23.0 h1:V2/ZgjfDFIygAX3ZapeigkVBoVUtOJKSwrhZdlpSvaA=
 github.com/btcsuite/btcd v0.23.0/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
@@ -221,7 +222,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
-github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
+github.com/cespare/cp v1.0.0 h1:47QuPGrUwHTJLdv2MeejqLT29EfhvKzfH+OMBvayz80=
+github.com/cespare/cp v1.0.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=

--- a/models/collections.go
+++ b/models/collections.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.
@@ -20,6 +20,57 @@ import (
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/chain4travel/magellan/modelsc"
 )
+
+type DACProposalWithVotes struct {
+	DACProposal DACProposal `json:"dacProposal"`
+	DACVotes    []DACVote   `json:"dacVotes"`
+}
+
+type DACProposalsList struct {
+	DACProposals []DACProposalWithVotes `json:"dacProposals"`
+}
+
+type ProposalStatus int
+
+const (
+	ProposalStatusInProgress ProposalStatus = iota
+	ProposalStatusSuccess
+	ProposalStatusFailed
+	ProposalStatusCompleted // both success and failed
+)
+
+type ProposalType int
+
+const (
+	ProposalTypeBaseFee ProposalType = iota
+	ProposalTypeAddMember
+	ProposalTypeExcludeMember
+	ProposalTypeGeneral
+	ProposalTypeFeeDistribution
+)
+
+type DACProposal struct {
+	ID              string         `json:"id"`                   // proposal id, also addProposalTx id
+	ProposerAddr    string         `json:"proposerAddr"`         // address which authorized proposal
+	StartTime       time.Time      `json:"startTime"`            // time when proposal will become votable
+	EndTime         time.Time      `json:"endTime"`              // time when proposal will become non-votable and will be executed if its successful
+	FinishedAt      *time.Time     `json:"finishedAt,omitempty"` // time when proposal was finished
+	Type            ProposalType   `json:"type"`                 // proposal type
+	IsAdminProposal bool           `json:"admin_proposal"`       // true if it is admin proposal
+	Options         []byte         `json:"options"`              // proposal votable options
+	Data            []byte         `json:"data,omitempty"`       // arbitrary proposal data
+	Memo            []byte         `json:"memo"`                 // addProposalTx memo
+	Outcome         []byte         `json:"outcome,omitempty"`    // outcome of successful proposal, usually is one or multiple options indexes
+	Status          ProposalStatus `json:"status"`               // current status of proposal
+	BlockHeight     uint64         `json:"blockHeight"`          // height of proposal block
+}
+
+type DACVote struct {
+	VoteTxID     string    `json:"voteTxID"`     // addVoteTx id
+	VoterAddr    string    `json:"voterAddr"`    // address which authorized this vote
+	VotedAt      time.Time `json:"votedAt"`      // timestamp when this vote happened
+	VotedOptions []byte    `json:"votedOptions"` // proposal options that was voted by this vote, usually one or multiple option indexes
+}
 
 type MultisigAliasList struct {
 	Alias []string `json:"alias"`

--- a/models/types.go
+++ b/models/types.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // (c) 2021, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -46,8 +56,6 @@ var (
 	TransactionTypeTransformSubnet            TransactionType = 0x16
 	TransactionTypeAddPermissionlessValidator TransactionType = 0x17
 	TransactionTypeAddPermissionlessDelegator TransactionType = 0x18
-	TransactionTypeAddDaoProposal             TransactionType = 0x19
-	TransactionTypeAddDaoVote                 TransactionType = 0x20
 
 	// Camino Custom Datatypes
 
@@ -73,6 +81,9 @@ var (
 	TransactionTypeClaimReward           TransactionType = RegisterTransactionTypeCustom + 10
 	TransactionTypeRewardsImport         TransactionType = RegisterTransactionTypeCustom + 11
 	TransactionTypeAddDepositOffer       TransactionType = RegisterTransactionTypeCustom + 15
+	TransactionTypeAddDACProposal        TransactionType = RegisterTransactionTypeCustom + 16
+	TransactionTypeAddDACVote            TransactionType = RegisterTransactionTypeCustom + 17
+	TransactionTypeFinishDACProposals    TransactionType = RegisterTransactionTypeCustom + 18
 
 	ResultTypeTransaction SearchResultType = "transaction"
 	ResultTypeAsset       SearchResultType = "asset"
@@ -136,10 +147,12 @@ func (t TransactionType) String() string {
 		return "add_permissionless_validator"
 	case TransactionTypeAddPermissionlessDelegator:
 		return "add_permissionless_delegator"
-	case TransactionTypeAddDaoProposal:
-		return "add_dao_proposal"
-	case TransactionTypeAddDaoVote:
-		return "add_dao_vote"
+	case TransactionTypeAddDACProposal:
+		return "add_dac_proposal"
+	case TransactionTypeAddDACVote:
+		return "add_dac_vote"
+	case TransactionTypeFinishDACProposals:
+		return "finish_dac_proposals"
 	case TransactionTypeAddAddressState:
 		return "address_state"
 	case TransactionTypeDeposit:

--- a/services/db/migrations/054_dac_proposals_and_votes.down.sql
+++ b/services/db/migrations/054_dac_proposals_and_votes.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX dac_votes_by_proposal_id;
+DROP TABLE dac_votes;
+
+DROP INDEX dac_proposals_by_id;
+DROP TABLE dac_proposals;

--- a/services/db/migrations/054_dac_proposals_and_votes.up.sql
+++ b/services/db/migrations/054_dac_proposals_and_votes.up.sql
@@ -1,0 +1,29 @@
+CREATE TABLE `dac_proposals` (
+  id                VARCHAR(50)      NOT NULL PRIMARY KEY,
+  proposer_addr     VARCHAR(50)      NOT NULL,
+  start_time        TIMESTAMP        NOT NULL,
+  end_time          TIMESTAMP        NOT NULL,
+  type              TINYINT          NOT NULL,
+  admin_proposal    BOOLEAN          NOT NULL,
+  serialized_bytes  VARBINARY(1024)  NOT NULL,
+  finished_at       TIMESTAMP,
+  options           VARBINARY(1024)  NOT NULL,
+  data              VARBINARY(1024),
+  outcome           VARBINARY(1024),
+  status            TINYINT          NOT NULL
+);
+
+CREATE UNIQUE INDEX dac_proposals_by_id ON dac_proposals (id);
+
+CREATE TABLE `dac_votes` (
+  id             VARCHAR(50)      NOT NULL PRIMARY KEY,
+  voter_addr     VARCHAR(50)      NOT NULL,
+  voted_at       TIMESTAMP        NOT NULL,
+  proposal_id    VARCHAR(50)      NOT NULL,
+  voted_options  VARBINARY(1024)  NOT NULL,
+
+  FOREIGN KEY    (proposal_id)    REFERENCES dac_proposals(id)
+);
+ 
+ 
+CREATE INDEX dac_votes_by_proposal_id ON dac_votes (proposal_id);

--- a/services/indexes/params/params.go
+++ b/services/indexes/params/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.
@@ -24,31 +24,35 @@ import (
 )
 
 const (
-	KeyID               = "id"
-	KeyChainID          = "chainID"
-	KeyAddress          = "address"
-	KeyToAddress        = "toAddress"
-	KeyFromAddress      = "fromAddress"
-	KeyBlockStart       = "blockStart"
-	KeyBlockEnd         = "blockEnd"
-	KeyHash             = "hash"
-	KeyAlias            = "alias"
-	KeyAssetID          = "assetID"
-	KeySearchQuery      = "query"
-	KeySortBy           = "sort"
-	KeyLimit            = "limit"
-	KeyOffset           = "offset"
-	KeySpent            = "spent"
-	KeyStartTime        = "startTime"
-	KeyEndTime          = "endTime"
-	KeyIntervalSize     = "intervalSize"
-	KeyDisableCount     = "disableCount"
-	KeyDisableGenesis   = "disableGenesis"
-	KeyOutputOutputType = "outputOutputType"
-	KeyOutputGroupID    = "outputGroupId"
-	KeyTransactionID    = "transactionId"
-	KeyRPC              = "rpc"
-	KeyRaw              = "raw"
+	KeyID                   = "id"
+	KeyChainID              = "chainID"
+	KeyAddress              = "address"
+	KeyToAddress            = "toAddress"
+	KeyFromAddress          = "fromAddress"
+	KeyBlockStart           = "blockStart"
+	KeyBlockEnd             = "blockEnd"
+	KeyHash                 = "hash"
+	KeyAlias                = "alias"
+	KeyAssetID              = "assetID"
+	KeySearchQuery          = "query"
+	KeySortBy               = "sort"
+	KeyLimit                = "limit"
+	KeyOffset               = "offset"
+	KeySpent                = "spent"
+	KeyStartTime            = "startTime"
+	KeyEndTime              = "endTime"
+	KeyIntervalSize         = "intervalSize"
+	KeyDisableCount         = "disableCount"
+	KeyDisableGenesis       = "disableGenesis"
+	KeyOutputOutputType     = "outputOutputType"
+	KeyOutputGroupID        = "outputGroupId"
+	KeyTransactionID        = "transactionId"
+	KeyProposalType         = "proposalType"
+	KeyProposalStatus       = "proposalStatus"
+	KeyProposalMinStartTime = "minStartTime"
+	KeyProposalMaxStartTime = "maxStartTime"
+	KeyRPC                  = "rpc"
+	KeyRaw                  = "raw"
 
 	PaginationMaxLimit      = 5000
 	PaginationDefaultOffset = 0


### PR DESCRIPTION
## Why this should be merged
This PR adds support for DAC voting feature txs, which includes txs indexing and 2 api requests: `/proposals?` and `/proposals/:id/votes`

## How this works
Added txs:
- AddProposalTx
- AddVoteTx
- FinishProposalsTx

Added proposals and their magellan types:
- AdminProposal
- BaseFeeProposal (0)
- AddMemberProposal (1)
- ExcludeMemberProposal (2)
- GeneralProposal (3)
- FeeDistributionProposal (4)

Admin proposal is flag in proposals table.

PR adds new tables: `dac-proposals` and `dac-votes`.
When magellan indexes new tx, if its addProposalTx, it will insert new row into proposals table. If its addVoteTx, then it will insert new row into votes table.
Proposals table also contains serialized proposalState from proposal. This state is updated whenever addVoteTx is indexed. Its required to have correct proposal outcome.

Proposal has state and outcome. Outcome is some arbitrary byte returned by proposal.Outcome(), only expected from successful proposals. State is one of following: 0 - in progress (could be still inactive if its before start-time, but thats not tracked in magellan), 1 - successful, 2 - failed.

Proposal state and outcome are updated, when finishProposalsTx is indexed.
## How this was tested
Unit-tests, manual tests with local node and db exploring.